### PR TITLE
Исправление для задачи 3257

### DIFF
--- a/VodovozBusiness/EntityRepositories/Logistic/CarRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Logistic/CarRepository.cs
@@ -41,7 +41,7 @@ namespace Vodovoz.EntityRepositories.Logistic
 		public bool IsInAnyRouteList(IUnitOfWork uow, Car car)
         {
 			var rll = uow.Session.QueryOver<RouteList>()
-				.Where(rl => rl.Car == car).List();
+				.Where(rl => rl.Car == car).Take(1).List();
 
 			return rll.Any();
         }


### PR DESCRIPTION
Выборка для проверки наличия автомобиля в МЛ ограничена 1 записью