### PR TITLE
NullReferenceException в случае передачи null в Client в Order

### DIFF
--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -35,7 +35,6 @@ using Vodovoz.EntityRepositories.Store;
 using Vodovoz.Models;
 using Vodovoz.Parameters;
 using Vodovoz.Repositories.Client;
-using Vodovoz.Repository.Client;
 using Vodovoz.Services;
 using Vodovoz.Tools.CallTasks;
 using Vodovoz.Tools.Orders;
@@ -125,8 +124,11 @@ namespace Vodovoz.Domain.Orders
 			set {
 				if(value == client)
 					return;
-				IsForRetail = value.IsForRetail;
-				if(orderRepository.GetOnClosingOrderStatuses().Contains(OrderStatus)) {
+				if(value != null)
+                {
+					IsForRetail = value.IsForRetail;
+				}
+				if (orderRepository.GetOnClosingOrderStatuses().Contains(OrderStatus)) {
 					OnChangeCounterparty(value);
 				} else if(client != null && !CanChangeContractor()) {
 					OnPropertyChanged(nameof(Client));

--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -124,10 +124,6 @@ namespace Vodovoz.Domain.Orders
 			set {
 				if(value == client)
 					return;
-				if(value != null)
-                {
-					IsForRetail = value.IsForRetail;
-				}
 				if (orderRepository.GetOnClosingOrderStatuses().Contains(OrderStatus)) {
 					OnChangeCounterparty(value);
 				} else if(client != null && !CanChangeContractor()) {
@@ -148,6 +144,10 @@ namespace Vodovoz.Domain.Orders
                     if(oldClient != null) {
 						UpdateContract();
                     }
+					if (value != null)
+					{
+						IsForRetail = value.IsForRetail;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Добавлена проверка на null входящего значения в set для Свойства Client заказа для установки IsForRetail
Установка значения при обновлении контрагента происходит только после установки контрагента.