### PR TITLE
При отправке МЛ на погрузку в предупреждение добавлены тмц, которые отсутствуют в перечне остатков склада

### DIFF
--- a/Vodovoz/Representations/RouteListsVM.cs
+++ b/Vodovoz/Representations/RouteListsVM.cs
@@ -377,6 +377,18 @@ namespace Vodovoz.ViewModel
 										.Where(w=> w.Stock < w.Count);
 
 									messageStockList.AddRange(lackWarehouseStocks);
+
+									var notExistInWarehouseNomenclatures = onlineOrders
+										.Where(o => !warehouseStocks.Any(w => w.NomenclatureId == o.Nomenclature.Id))
+										.Select(o => new LackStockNode()
+										{
+											OrderId = o.Order.Id,
+											NomenclatureName = o.Nomenclature.Name,
+											Count = o.Count,
+											Measure = o.Nomenclature.Unit.Name
+										});
+
+									messageStockList.AddRange(notExistInWarehouseNomenclatures);
 								}
 							}
 
@@ -585,8 +597,8 @@ namespace Vodovoz.ViewModel
 		
 		private class LackStockNode
 		{
-			public int OrderId;
 			public int NomenclatureId;
+			public int OrderId;
 			public string NomenclatureName;
 			public decimal Count;
 			public decimal Stock;


### PR DESCRIPTION
Дополнение к задаче I-3299. Помимо вывода в предупреждении тех тмц, отстатки на складе по которым меньше, чем в заказе (запрос к базе по складу), в предупреждение добавлены тмц, которые совсем отсутствуют на складе (не возвращаются запросом  к базе)