### PR TITLE
Хотфикс 3361 отображение времени в отчёте по изменениям

### DIFF
--- a/Vodovoz/Reports/Orders/OrderChangesReport.rdl
+++ b/Vodovoz/Reports/Orders/OrderChangesReport.rdl
@@ -535,7 +535,7 @@
                   <ReportItems>
                     <Textbox Name="Textbox21">
                       <Value>= Format(Convert.ToDateTime({delivery_date}), "dd.MM.yyyy") + ' ' + Iif(Fields!time_delivered.IsMissing, '', 
-Format(Convert.ToDateTime({time_delivered}), "HH:mm"))</Value>
+Format(Convert.ToDateTime({time_delivered}), "HH:mm:ss"))</Value>
                       <CanGrow>true</CanGrow>
                       <Style>
                         <BorderStyle>

--- a/Vodovoz/Reports/Orders/OrderChangesReport.rdl
+++ b/Vodovoz/Reports/Orders/OrderChangesReport.rdl
@@ -734,7 +734,9 @@ Format(Convert.ToDateTime({time_delivered}), "HH:mm"))</Value>
                                AND hc.field_name = 'DeliveryDate'
         WHERE hce.entity_class = 'Order'
           AND hce.entity_id = source.order_id
-          AND hce.operation = 'Create'
+		  AND hce.operation IN ('Create', 'Change')
+		  AND hc.new_value IS NOT NULL
+		ORDER BY hc.new_value 
         LIMIT 1
     ) AS delivery_date,
     (
@@ -745,7 +747,9 @@ Format(Convert.ToDateTime({time_delivered}), "HH:mm"))</Value>
                                AND hc.field_name = 'TimeDelivered'
         WHERE hce.entity_class = 'Order'
           AND hce.entity_id = source.order_id
-          AND hce.operation = 'Create'
+		  AND hce.operation IN ('Create', 'Change')
+		  AND hc.new_value IS NOT NULL
+		ORDER BY hc.new_value 
         LIMIT 1
     ) AS time_delivered,
     source.change_time,


### PR DESCRIPTION
В базу не записываются операции Create для TimeDelivered, только операции Change. Поэтому добавлен поиск по операции Change. Операция Create также оставлена (если будет использоваться в будущем). Берётся самое первое ненулевое значение. Для DeliveryDate всё сделано аналогично.