### PR TITLE
Задача 3305 тип принадлежности оборудования при погрузке

### DIFF
--- a/Vodovoz/Dialogs/DocumentDialogs/CarLoadDocumentView.cs
+++ b/Vodovoz/Dialogs/DocumentDialogs/CarLoadDocumentView.cs
@@ -6,6 +6,7 @@ using QS.Dialog.GtkUI;
 using QS.DomainModel.UoW;
 using QSOrmProject;
 using Vodovoz.Domain.Documents;
+using Vodovoz.Domain.Orders;
 using Vodovoz.EntityRepositories.Logistic;
 using Vodovoz.EntityRepositories.Subdivisions;
 using Vodovoz.Infrastructure.Converters;
@@ -21,6 +22,7 @@ namespace Vodovoz
 
 			ytreeviewItems.ColumnsConfig = ColumnsConfigFactory.Create<CarLoadDocumentItem>()
 				.AddColumn("Номенклатура").AddTextRenderer(x => (x.ExpireDatePercent != null) ? x.Nomenclature.Name + " >" + x.ExpireDatePercent + "% срока годности" : x.Nomenclature.Name)
+				.AddColumn("Принадлежность").AddEnumRenderer(x => x.OwnType, true, new Enum[] { OwnTypes.None })
 				.AddColumn("С/Н оборудования").AddTextRenderer(x => x.Equipment != null ? x.Equipment.Serial : String.Empty)
 				.AddColumn("Кол-во на складе").AddTextRenderer(x => x.Nomenclature.Unit.MakeAmountShortStr(x.AmountInStock))
 				.AddColumn("В маршрутнике").AddTextRenderer(x => x.Nomenclature.Unit.MakeAmountShortStr(x.AmountInRouteList))

--- a/Vodovoz/Reports/Store/CarLoadDocument.rdl
+++ b/Vodovoz/Reports/Store/CarLoadDocument.rdl
@@ -13,7 +13,7 @@
   <BottomMargin>.25in</BottomMargin>
   <DataSets>
     <DataSet Name="Data">
-      <Query >
+      <Query>
         <DataSourceName>DS1</DataSourceName>
         <CommandText>SELECT
     IF (scldi.item_expiration_date_percent IS NOT NULL
@@ -54,7 +54,7 @@ ORDER BY clmn_for_sorting;</CommandText>
           </QueryParameter>
         </QueryParameters>
       </Query>
-      <Fields >
+      <Fields>
         <Field Name="nomenclature">
           <DataField>nomenclature</DataField>
           <rd:TypeName>System.String</rd:TypeName>
@@ -161,14 +161,11 @@ LIMIT 1
     <DataSet Name="Equipment">
       <Query>
         <DataSourceName>DS1</DataSourceName>
-        <CommandText>#OrderItem
-SELECT 
+        <CommandText>SELECT 
 	scldi.amount as count,
-	rla.order_id,
 	mu.digits,
-	oe.id,
-	IF(oe.id IS NOT NULL,
-		CASE oe.own_type
+	IF(scldi.own_type IS NOT NULL,
+		CASE scldi.own_type
 			WHEN 'None'  THEN n.official_name
 			WHEN 'Client'THEN CONCAT(n.official_name, ' (Клиент)')
 			WHEN 'Duty'	 THEN CONCAT(n.official_name, ' (Дежурный)')
@@ -181,21 +178,18 @@ LEFT JOIN
     store_car_load_documents scld ON scld.id = scldi.car_load_document_id 
 LEFT JOIN nomenclature n ON n.id = scldi.nomenclature_id
 LEFT JOIN measurement_units mu ON mu.id = n.unit_id
-LEFT JOIN route_list_addresses rla ON rla.route_list_id = scld.route_list_id
-LEFT JOIN orders ON rla.order_id = orders.id 
-LEFT JOIN order_equipment oe ON oe.order_id = orders.id AND oe.nomenclature_id = scldi.nomenclature_id
 WHERE
-	scld.id = @id
+	scldi.car_load_document_id = @id
 	AND n.category IN ('equipment', 'additional', 'spare_parts', 'material', 'fuel', 'bottle', 'CashEquipment')
 	AND n.online_store_external_id IS NULL
-GROUP BY n.id</CommandText>
+GROUP BY n.id, scldi.own_type </CommandText>
         <QueryParameters>
           <QueryParameter Name="id">
             <Value>={?id}</Value>
           </QueryParameter>
         </QueryParameters>
       </Query>
-      <Fields>
+      <Fields >
         <Field Name="official_name">
           <DataField>official_name</DataField>
           <TypeName>System.String</TypeName>
@@ -203,10 +197,6 @@ GROUP BY n.id</CommandText>
         <Field Name="count">
           <DataField>count</DataField>
           <TypeName>System.Decimal</TypeName>
-        </Field>
-        <Field Name="order_id">
-          <DataField>order_id</DataField>
-          <TypeName>System.UInt32</TypeName>
         </Field>
         <Field Name="digits">
           <DataField>digits</DataField>

--- a/VodovozBusiness/Domain/Documents/CarLoadDocument.cs
+++ b/VodovozBusiness/Domain/Documents/CarLoadDocument.cs
@@ -107,6 +107,7 @@ namespace Vodovoz.Domain.Documents
 					new CarLoadDocumentItem {
 						Document = this,
 						Nomenclature = nomenclatures.First(x => x.Id == inRoute.NomenclatureId),
+						OwnType = inRoute.OwnType,
 						ExpireDatePercent = inRoute.ExpireDatePercent,
 						AmountInRouteList = inRoute.Amount,
 						Amount = inRoute.Amount

--- a/VodovozBusiness/Domain/Documents/CarLoadDocumentItem.cs
+++ b/VodovozBusiness/Domain/Documents/CarLoadDocumentItem.cs
@@ -22,14 +22,14 @@ namespace Vodovoz.Domain.Documents
 
 		public virtual CarLoadDocument Document {
 			get { return document; }
-			set { SetField (ref document, value, () => Document); }
+			set { SetField (ref document, value); }
 		}
 
 		WarehouseMovementOperation warehouseMovementOperation;
 
 		public virtual WarehouseMovementOperation WarehouseMovementOperation { 
 			get { return warehouseMovementOperation; }
-			set { SetField (ref warehouseMovementOperation, value, () => WarehouseMovementOperation); }
+			set { SetField (ref warehouseMovementOperation, value); }
 		}
 
 		EmployeeNomenclatureMovementOperation employeeNomenclatureMovementOperation;
@@ -44,7 +44,7 @@ namespace Vodovoz.Domain.Documents
 		public virtual Nomenclature Nomenclature {
 			get { return nomenclature; }
 			set {
-				SetField (ref nomenclature, value, () => Nomenclature);
+				SetField (ref nomenclature, value);
 
 				if (WarehouseMovementOperation != null && WarehouseMovementOperation.Nomenclature != nomenclature)
 					WarehouseMovementOperation.Nomenclature = nomenclature;
@@ -57,7 +57,7 @@ namespace Vodovoz.Domain.Documents
 		public virtual Equipment Equipment {
 			get { return equipment; }
 			set {
-				SetField (ref equipment, value, () => Equipment);
+				SetField (ref equipment, value);
 				if (WarehouseMovementOperation != null && WarehouseMovementOperation.Equipment != equipment)
 					WarehouseMovementOperation.Equipment = equipment;
 			}
@@ -69,7 +69,7 @@ namespace Vodovoz.Domain.Documents
 		public virtual OwnTypes OwnType
 		{
 			get => ownType;
-			set => SetField(ref ownType, value, () => OwnType);
+			set => SetField(ref ownType, value);
 		}
 
 		decimal amount;
@@ -77,7 +77,7 @@ namespace Vodovoz.Domain.Documents
 		[Display (Name = "Количество")]
 		public virtual decimal Amount {
 			get => amount;
-			set => SetField (ref amount, value, () => Amount);
+			set => SetField (ref amount, value);
 		}
 
 		decimal? expireDatePercent;
@@ -85,7 +85,7 @@ namespace Vodovoz.Domain.Documents
 		public virtual decimal? ExpireDatePercent {
 			get => expireDatePercent; 
 			set {
-				SetField(ref expireDatePercent, value, () => ExpireDatePercent);
+				SetField(ref expireDatePercent, value);
 			} 
 		}
 
@@ -99,7 +99,7 @@ namespace Vodovoz.Domain.Documents
 		public virtual decimal AmountInStock {
 			get { return amountInStock; }
 			set {
-				SetField (ref amountInStock, value, () => AmountInStock);
+				SetField (ref amountInStock, value);
 			}
 		}
 
@@ -109,7 +109,7 @@ namespace Vodovoz.Domain.Documents
 		public virtual decimal AmountInRouteList {
 			get { return amountInRouteList; }
 			set {
-				SetField (ref amountInRouteList, value, () => AmountInRouteList);
+				SetField (ref amountInRouteList, value);
 			}
 		}
 
@@ -119,7 +119,7 @@ namespace Vodovoz.Domain.Documents
 		public virtual decimal AmountLoaded {
 			get { return amountLoaded; }
 			set {
-				SetField (ref amountLoaded, value, () => AmountLoaded);
+				SetField (ref amountLoaded, value);
 			}
 		}
 			

--- a/VodovozBusiness/Domain/Documents/CarLoadDocumentItem.cs
+++ b/VodovozBusiness/Domain/Documents/CarLoadDocumentItem.cs
@@ -4,6 +4,7 @@ using QS.DomainModel.Entity;
 using QS.HistoryLog;
 using Vodovoz.Domain.Goods;
 using Vodovoz.Domain.Operations;
+using Vodovoz.Domain.Orders;
 using Vodovoz.Domain.Store;
 
 namespace Vodovoz.Domain.Documents
@@ -60,6 +61,15 @@ namespace Vodovoz.Domain.Documents
 				if (WarehouseMovementOperation != null && WarehouseMovementOperation.Equipment != equipment)
 					WarehouseMovementOperation.Equipment = equipment;
 			}
+		}
+
+		OwnTypes ownType;
+
+		[Display(Name = "Принадлежность")]
+		public virtual OwnTypes OwnType
+		{
+			get => ownType;
+			set => SetField(ref ownType, value, () => OwnType);
 		}
 
 		decimal amount;

--- a/VodovozBusiness/Domain/Orders/OrderEquipment.cs
+++ b/VodovozBusiness/Domain/Orders/OrderEquipment.cs
@@ -63,7 +63,6 @@ namespace Vodovoz.Domain.Orders
 			set => SetField(ref ownType, value, () => OwnType);
 		}
 
-
 		Nomenclature nomenclature;
 
 		[Display(Name = "Номенклатура оборудования")]

--- a/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
@@ -103,16 +103,33 @@ namespace Vodovoz.EntityRepositories.Logistic
 			}
 
 			return result
-				.GroupBy(
-					x => x.NomenclatureName,
-					x => x,
-					(key, value) => new GoodsInRouteListResultWithSpecialRequirements()
+				.GroupBy(x => new
 					{
-						NomenclatureName = key,
-						NomenclatureId = value.FirstOrDefault().NomenclatureId,
-						ExpireDatePercent = value.FirstOrDefault().ExpireDatePercent,
-						Amount = value.Sum(x => x.Amount)
-					}).ToList();
+						x.NomenclatureId,
+						x.ExpireDatePercent,
+						x.OwnType
+					}
+				).Select(list => new GoodsInRouteListResultWithSpecialRequirements()
+					{
+						NomenclatureName = list.FirstOrDefault().NomenclatureName,
+						NomenclatureId = list.Key.NomenclatureId,
+						OwnType = list.Key.OwnType,
+						ExpireDatePercent = list.Key.ExpireDatePercent,
+						Amount = list.Sum(x => x.Amount)
+					}
+				).ToList();
+
+				//.GroupBy(
+				//	x => x.NomenclatureName,
+				//	x => x,
+				//	(key, value) => new GoodsInRouteListResultWithSpecialRequirements()
+				//	{
+				//		NomenclatureName = key,
+				//		NomenclatureId = value.FirstOrDefault().NomenclatureId,
+				//		OwnType = value.FirstOrDefault().OwnType,
+				//		ExpireDatePercent = value.FirstOrDefault().ExpireDatePercent,
+				//		Amount = value.Sum(x => x.Amount)
+				//	}).ToList();
 		}
 
 		public IList<GoodsInRouteListResult> GetGoodsAndEquipsInRL(
@@ -264,12 +281,13 @@ namespace Vodovoz.EntityRepositories.Logistic
 
 			return orderEquipmentsQuery
 				.SelectList(list => list
-				   .SelectGroup(() => OrderEquipmentNomenclatureAlias.Id).WithAlias(() => resultAlias.NomenclatureId)
-							.Select(Projections.Sum(
-								Projections.Cast(NHibernateUtil.Decimal, Projections.Property(() => orderEquipmentAlias.Count))
-							)).WithAlias(() => resultAlias.Amount)
-							.Select(() => OrderEquipmentNomenclatureAlias.Name).WithAlias(() => resultAlias.NomenclatureName)
-
+					.SelectGroup(() => OrderEquipmentNomenclatureAlias.Id).WithAlias(() => resultAlias.NomenclatureId)
+					.SelectGroup(() => orderEquipmentAlias.OwnType).WithAlias(() => resultAlias.OwnType)
+					.Select(Projections.Sum(
+						Projections.Cast(NHibernateUtil.Decimal, Projections.Property(() => orderEquipmentAlias.Count))
+					)).WithAlias(() => resultAlias.Amount)
+					.Select(() => OrderEquipmentNomenclatureAlias.Name).WithAlias(() => resultAlias.NomenclatureName)
+					.Select(() => orderEquipmentAlias.OwnType).WithAlias(() => resultAlias.OwnType)
 				)
 				.TransformUsing(Transformers.AliasToBean<GoodsInRouteListResultWithSpecialRequirements>())
 				.List<GoodsInRouteListResultWithSpecialRequirements>();
@@ -717,6 +735,7 @@ namespace Vodovoz.EntityRepositories.Logistic
 	{
 		public int NomenclatureId { get; set; }
 		public string NomenclatureName { get; set; }
+		public OwnTypes OwnType { get; set; }
 		public decimal? ExpireDatePercent { get; set; } = null;
 		public decimal Amount { get; set; }
 	}

--- a/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
@@ -118,18 +118,6 @@ namespace Vodovoz.EntityRepositories.Logistic
 						Amount = list.Sum(x => x.Amount)
 					}
 				).ToList();
-
-				//.GroupBy(
-				//	x => x.NomenclatureName,
-				//	x => x,
-				//	(key, value) => new GoodsInRouteListResultWithSpecialRequirements()
-				//	{
-				//		NomenclatureName = key,
-				//		NomenclatureId = value.FirstOrDefault().NomenclatureId,
-				//		OwnType = value.FirstOrDefault().OwnType,
-				//		ExpireDatePercent = value.FirstOrDefault().ExpireDatePercent,
-				//		Amount = value.Sum(x => x.Amount)
-				//	}).ToList();
 		}
 
 		public IList<GoodsInRouteListResult> GetGoodsAndEquipsInRL(

--- a/VodovozBusiness/HibernateMapping/Documents/CarLoadDocumentItemMap.cs
+++ b/VodovozBusiness/HibernateMapping/Documents/CarLoadDocumentItemMap.cs
@@ -1,5 +1,6 @@
 ﻿using FluentNHibernate.Mapping;
 using Vodovoz.Domain.Documents;
+using Vodovoz.Domain.Orders;
 
 namespace Vodovoz.HibernateMapping
 {
@@ -13,6 +14,7 @@ namespace Vodovoz.HibernateMapping
 
             Map(x => x.Amount).Column("amount");
             Map(x => x.ExpireDatePercent).Column("item_expiration_date_percent");
+            Map(x => x.OwnType).Column("own_type").CustomType<OwnTypesStringType>();
 
             References(x => x.Nomenclature).Column("nomenclature_id");
             References(x => x.Equipment).Column("equipment_id");


### PR DESCRIPTION
Теперь тип принадлежности оборудования хранится в документах погрузки.
Исправлено отображение принадлежности в печатной форме талона погрузки.