### PR TITLE
3288 - отсечение дробной части в номенклатурах заказа (для целочисленных единиц измерения)

### DIFF
--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -3813,18 +3813,8 @@ namespace Vodovoz.Domain.Orders
 
 		protected internal virtual void ObservableOrderItems_ListContentChanged(object sender, EventArgs e)
 		{
-			UpdateOrderItemCountDigitsForInt(sender as IList<OrderItem>);
 			OnPropertyChanged(nameof(TotalSum));
 			UpdateDocuments();
-		}
-		
-		void UpdateOrderItemCountDigitsForInt(IList<OrderItem> orderItems)
-		{
-			foreach (var orderItem in orderItems)
-			{
-				if(orderItem.Nomenclature.Unit?.Digits == 0 && orderItem.Count % 1 != 0)
-					orderItem.Count = Math.Truncate(orderItem.Count);
-			}
 		}
 
 		#endregion

--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -3813,8 +3813,18 @@ namespace Vodovoz.Domain.Orders
 
 		protected internal virtual void ObservableOrderItems_ListContentChanged(object sender, EventArgs e)
 		{
+			UpdateOrderItemCountDigitsForInt(sender as IList<OrderItem>);
 			OnPropertyChanged(nameof(TotalSum));
 			UpdateDocuments();
+		}
+		
+		void UpdateOrderItemCountDigitsForInt(IList<OrderItem> orderItems)
+		{
+			foreach (var orderItem in orderItems)
+			{
+				if(orderItem.Nomenclature.Unit?.Digits == 0 && orderItem.Count % 1 != 0)
+					orderItem.Count = Math.Truncate(orderItem.Count);
+			}
 		}
 
 		#endregion

--- a/VodovozBusiness/Domain/Orders/OrderItem.cs
+++ b/VodovozBusiness/Domain/Orders/OrderItem.cs
@@ -90,6 +90,8 @@ namespace Vodovoz.Domain.Orders
 		public virtual decimal Count {
 			get => count;
 			set {
+				if(Nomenclature?.Unit.Digits == 0 && value % 1 != 0)
+					value = Math.Truncate(value);
 				if(SetField(ref count, value)) {
 					Order?.RecalculateItemsPrice();
 					RecalculateDiscount();

--- a/VodovozBusiness/Domain/Orders/OrderItem.cs
+++ b/VodovozBusiness/Domain/Orders/OrderItem.cs
@@ -90,7 +90,7 @@ namespace Vodovoz.Domain.Orders
 		public virtual decimal Count {
 			get => count;
 			set {
-				if(Nomenclature?.Unit.Digits == 0 && value % 1 != 0)
+				if(Nomenclature?.Unit?.Digits == 0 && value % 1 != 0)
 					value = Math.Truncate(value);
 				if(SetField(ref count, value)) {
 					Order?.RecalculateItemsPrice();


### PR DESCRIPTION
При указании в заказе для номенклатуры с целочисленной единицей измерения (н-р, штуки) нецелого количества (н-р, =1,2 как в МЛ 117993) в колонке отображалось целое число, а в бд записывалось введённое (с дробной частью). Далее при отгрузке МЛ такая номенклатура отображалась в списке не отгруженных. Добавлено отсечение дробной части для целочисленных единиц измерения (для единиц измерения с точностью=0).