### PR TITLE
3083-Горячие клавиши

### DIFF
--- a/Vodovoz/Commons/HotkeyHandler.cs
+++ b/Vodovoz/Commons/HotkeyHandler.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using Gtk;
+using QS.Tdi.Gtk;
+
+namespace Vodovoz
+{
+    public static class HotKeyHandler
+    {
+        private static Gtk.Clipboard clipboard = Gtk.Clipboard.Get(Gdk.Atom.Intern("CLIPBOARD", false));
+        public static void HandleKeyPressEvent(object o, KeyPressEventArgs args)
+        {
+            TdiNotebook mainNotebook = MainClass.MainWin.TdiMain;
+            if (mainNotebook == null)
+                throw new InvalidOperationException(
+                    "Вызвано событие TDIHandleKeyPressEvent, но для его корректной работы необходимо заполнить TDIMain.MainNotebook.");
+
+            int platform = (int)Environment.OSVersion.Platform;
+            int version = Environment.OSVersion.Version.Major;
+            Gdk.ModifierType modifier;
+
+            //Kind of MacOSXCou
+            if ((platform == 4 || platform == 6 || platform == 128) && version > 8)
+                modifier = Gdk.ModifierType.MetaMask | Gdk.ModifierType.Mod1Mask;
+            //Kind of Windows or Unix
+            else
+                modifier = Gdk.ModifierType.ControlMask;
+
+            //CTRL+C	
+            if ((args.Event.Key == Gdk.Key.Cyrillic_es || args.Event.Key == Gdk.Key.Cyrillic_ES || args.Event.Key == Gdk.Key.c || args.Event.Key == Gdk.Key.C)
+                && args.Event.State.HasFlag(modifier))
+            {
+                Widget w = (o as Window).Focus;
+                CopyToClipboard(w);
+            }
+            //CTRL+X
+            else if ((args.Event.Key == Gdk.Key.Cyrillic_che || args.Event.Key == Gdk.Key.Cyrillic_CHE || args.Event.Key == Gdk.Key.x || args.Event.Key == Gdk.Key.X)
+                     && args.Event.State.HasFlag(modifier))
+            {
+                Widget w = (o as Window).Focus;
+                CutToClipboard(w);
+            }
+            //CTRL+V
+            else if ((args.Event.Key == Gdk.Key.Cyrillic_em || args.Event.Key == Gdk.Key.Cyrillic_EM || args.Event.Key == Gdk.Key.v || args.Event.Key == Gdk.Key.V)
+                     && args.Event.State.HasFlag(modifier))
+            {
+                Widget w = (o as Window).Focus;
+                PasteFromClipboard(w);
+            }
+            //CTRL+A
+            else if ((args.Event.Key == Gdk.Key.Cyrillic_ef || args.Event.Key == Gdk.Key.Cyrillic_EF || args.Event.Key == Gdk.Key.a || args.Event.Key == Gdk.Key.A)
+                     && args.Event.State.HasFlag(modifier))
+            {
+                Widget w = (o as Window).Focus;
+                SelectAllText(w);
+            }
+        }
+
+        private static void SelectAllText(Widget w)
+        {
+            if (w is Editable)
+                (w as Editable).SelectRegion(0, -1);
+            else if (w is TextView textView)
+            {
+                var start = textView.Buffer.GetIterAtOffset(0);
+                var end = textView.Buffer.GetIterAtOffset(0);
+                end.ForwardToEnd();
+                textView.Buffer.SelectRange(start, end);
+            }
+        }
+
+        private static void CopyToClipboard(Widget w)
+        {
+            int start, end;
+
+            if (w is Editable)
+                (w as Editable).CopyClipboard();
+            else if (w is TextView)
+                (w as TextView).Buffer.CopyClipboard(clipboard);
+            else if (w is Label)
+            {
+                (w as Label).GetSelectionBounds(out start, out end);
+                if (start != end)
+                    clipboard.Text = (w as Label).Text.Substring(start, end - start);
+            }
+        }
+
+        private static void CutToClipboard(Widget w)
+        {
+            int start, end;
+
+            if (w is Editable)
+                (w as Editable).CutClipboard();
+            else if (w is TextView)
+                (w as TextView).Buffer.CutClipboard(clipboard, true);
+            else if (w is Label)
+            {
+                (w as Label).GetSelectionBounds(out start, out end);
+                if (start != end)
+                    clipboard.Text = (w as Label).Text.Substring(start, end - start);
+            }
+        }
+
+        private static void PasteFromClipboard(Widget w)
+        {
+            if (w is Editable)
+                (w as Editable).PasteClipboard();
+            else if (w is TextView)
+                (w as TextView).Buffer.PasteClipboard(clipboard);
+        }
+    }
+}
+

--- a/Vodovoz/JournalViewModels/DeliveryPointJournalViewModel.cs
+++ b/Vodovoz/JournalViewModels/DeliveryPointJournalViewModel.cs
@@ -63,7 +63,8 @@ namespace Vodovoz.JournalViewModels
 					if(config.PermissionResult.CanDelete) {
 						DeleteHelper.DeleteEntity(selectedNode.EntityType, selectedNode.Id);
 					}
-				}
+				},
+				"Delete"
 			);
 			NodeActionsList.Add(deleteAction);
 		}

--- a/Vodovoz/MainWindow.cs
+++ b/Vodovoz/MainWindow.cs
@@ -106,6 +106,7 @@ using Vodovoz.Domain.Retail;
 using Vodovoz.Journals.FilterViewModels;
 using Vodovoz.FilterViewModels.Organization;
 using Vodovoz.Journals.JournalViewModels.Organization;
+using System.Runtime.InteropServices;
 
 public partial class MainWindow : Gtk.Window
 {
@@ -127,7 +128,7 @@ public partial class MainWindow : Gtk.Window
         tdiMain.WidgetResolver = ViewModelWidgetResolver.Instance;
         TDIMain.MainNotebook = tdiMain;
 
-        bool isWindows = System.IO.Path.DirectorySeparatorChar == '\\';
+        bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         if (isWindows)
             KeyPressEvent += HotKeyHandler.HandleKeyPressEvent;
 

--- a/Vodovoz/MainWindow.cs
+++ b/Vodovoz/MainWindow.cs
@@ -126,7 +126,11 @@ public partial class MainWindow : Gtk.Window
         BuildToolbarActions();
         tdiMain.WidgetResolver = ViewModelWidgetResolver.Instance;
         TDIMain.MainNotebook = tdiMain;
-        KeyReleaseEvent += TDIMain.TDIHandleKeyReleaseEvent;
+
+        bool isWindows = System.IO.Path.DirectorySeparatorChar == '\\';
+        if (isWindows)
+            KeyPressEvent += HotKeyHandler.HandleKeyPressEvent;
+
         Title = $"{applicationInfo.ProductTitle} v{applicationInfo.Version} от {applicationInfo.BuildDate:dd.MM.yyyy HH:mm}";
         //Настраиваем модули
         ActionUsers.Sensitive = QSMain.User.Admin;

--- a/Vodovoz/Vodovoz.csproj
+++ b/Vodovoz/Vodovoz.csproj
@@ -395,6 +395,7 @@
     <Compile Include="Additions\SmsPaymentSender.cs" />
     <Compile Include="Additions\SmsSender.cs" />
     <Compile Include="Commons\FileChooser.cs" />
+    <Compile Include="Commons\HotkeyHandler.cs" />
     <Compile Include="Core\WidgetResolveException.cs" />
     <Compile Include="Crutches\WrapLabel.cs" />
     <Compile Include="Filters\ViewModels\ProductGroupFilterViewModel.cs" />

--- a/VodovozViewModels/Journals/JournalViewModels/Cash/CashRequestJournalViewModel.cs
+++ b/VodovozViewModels/Journals/JournalViewModels/Cash/CashRequestJournalViewModel.cs
@@ -208,7 +208,8 @@ namespace Vodovoz.ViewModels.Journals.JournalViewModels.Cash
                     if(config.PermissionResult.CanDelete) {
                         DeleteHelper.DeleteEntity(selectedNode.EntityType, selectedNode.Id);
                     }
-                }
+                },
+               "Delete"
             );
             NodeActionsList.Add(deleteAction);
         }

--- a/VodovozViewModels/Journals/JournalViewModels/Proposal/ApplicationDevelopmentProposalsJournalViewModel.cs
+++ b/VodovozViewModels/Journals/JournalViewModels/Proposal/ApplicationDevelopmentProposalsJournalViewModel.cs
@@ -110,7 +110,8 @@ namespace Vodovoz.ViewModels.Journals.JournalViewModels.Proposal
 							slider.IsHideJournal = true;
 						}
 					}
-				});
+				},
+				"Insert");
 			NodeActionsList.Add(addAction);
 		}
 		protected override void CreatePopupActions()


### PR DESCRIPTION
Добавлено сочетание клавиш Ctrl+A для текстовых полей. Возвращены сочетания клавиш Ctrl+C, Ctrl+V, Ctrl+X для текстовых полей (исправлена двойная вставка при запуске ДВ на Windows с русской раскладкой клавиатуры).  Добавлены горячие клавиши Insert и Delete для действий JournalAction. 