### PR TITLE
3338 Исправление суммы, отправляемой в ЮКассу (распределение цен номенклатур)

### DIFF
--- a/Services/Application/VodovozSmsPaymentService/Program.cs
+++ b/Services/Application/VodovozSmsPaymentService/Program.cs
@@ -6,10 +6,10 @@ using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
 using System.Threading;
 using Android;
+using Microsoft.Extensions.Configuration;
 using Mono.Unix;
 using Mono.Unix.Native;
 using MySql.Data.MySqlClient;
-using Nini.Config;
 using NLog;
 using QS.Project.DB;
 using QSProjectsLib;
@@ -44,25 +44,29 @@ namespace VodovozSmsPaymentService
 		{
 			AppDomain.CurrentDomain.UnhandledException += AppDomain_CurrentDomain_UnhandledException;
 
-			try {
-				IniConfigSource confFile = new IniConfigSource(configFile);
-				confFile.Reload();
-				IConfig serviceConfig = confFile.Configs["Service"];
-				serviceHostName = serviceConfig.GetString("service_host_name");
-				servicePort = serviceConfig.GetString("service_port");
-				serviceWebPort = serviceConfig.GetString("service_web_port");
-				driverServiceHostName = serviceConfig.GetString("driver_service_host_name");
-				driverServicePort = serviceConfig.GetString("driver_service_port");
+			try
+			{
+				var builder = new ConfigurationBuilder()
+					.AddIniFile(configFile, optional: false);
 
-				IConfig bitrixConfig = confFile.Configs["Bitrix"];
-				baseAddress = bitrixConfig.GetString("base_address");
+				var configuration = builder.Build();
 
-				IConfig mysqlConfig = confFile.Configs["Mysql"];
-				mysqlServerHostName = mysqlConfig.GetString("mysql_server_host_name");
-				mysqlServerPort = mysqlConfig.GetString("mysql_server_port", "3306");
-				mysqlUser = mysqlConfig.GetString("mysql_user");
-				mysqlPassword = mysqlConfig.GetString("mysql_password");
-				mysqlDatabase = mysqlConfig.GetString("mysql_database");
+				var serviceSection = configuration.GetSection("Service");
+				serviceHostName = serviceSection["service_host_name"];
+				servicePort = serviceSection["service_port"];
+				serviceWebPort = serviceSection["service_web_port"];
+				driverServiceHostName = serviceSection["driver_service_host_name"];
+				driverServicePort = serviceSection["driver_service_port"];
+
+				var bitrixSection = configuration.GetSection("Bitrix");
+				baseAddress = bitrixSection["base_address"];
+
+				var mysqlSection = configuration.GetSection("Mysql");
+				mysqlServerHostName = mysqlSection["mysql_server_host_name"];
+				mysqlServerPort = mysqlSection["mysql_server_port"];
+				mysqlUser = mysqlSection["mysql_user"];
+				mysqlPassword = mysqlSection["mysql_password"];
+				mysqlDatabase = mysqlSection["mysql_database"];
 			}
 			catch(Exception ex) {
 				logger.Fatal(ex, "Ошибка чтения конфигурационного файла.");
@@ -141,11 +145,19 @@ namespace VodovozSmsPaymentService
 				unsavedPaymentsWorker.Start();
 				overduePaymentsWorker.Start();
 
-				UnixSignal[] signals = {
-					new UnixSignal (Signum.SIGINT),
-					new UnixSignal (Signum.SIGHUP),
-					new UnixSignal (Signum.SIGTERM)};
-				UnixSignal.WaitAny(signals);
+				if (Environment.OSVersion.Platform == PlatformID.Unix)
+				{
+					UnixSignal[] signals = {
+						new UnixSignal (Signum.SIGINT),
+						new UnixSignal (Signum.SIGHUP),
+						new UnixSignal (Signum.SIGTERM)
+					};
+					UnixSignal.WaitAny(signals);
+				}
+				else
+				{
+					Console.ReadLine();
+				}
 			}
 			catch(Exception e) {
 				logger.Fatal(e);

--- a/Services/Application/VodovozSmsPaymentService/VodovozSmsPaymentService.csproj
+++ b/Services/Application/VodovozSmsPaymentService/VodovozSmsPaymentService.csproj
@@ -111,9 +111,7 @@
       <PackageReference Include="K4os.Compression.LZ4" Version="1.2.6" />
       <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.2.6" />
       <PackageReference Include="K4os.Hash.xxHash" Version="1.0.6" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Ini">
-        <Version>1.1.0</Version>
-      </PackageReference>
+      <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="1.1.0"/>
       <PackageReference Include="MySql.Data" Version="8.0.24" />
       <PackageReference Include="NetTopologySuite" Version="2.2.0" />
       <PackageReference Include="NetTopologySuite.CoordinateSystems" Version="1.15.3" />

--- a/Services/Application/VodovozSmsPaymentService/VodovozSmsPaymentService.csproj
+++ b/Services/Application/VodovozSmsPaymentService/VodovozSmsPaymentService.csproj
@@ -111,6 +111,9 @@
       <PackageReference Include="K4os.Compression.LZ4" Version="1.2.6" />
       <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.2.6" />
       <PackageReference Include="K4os.Hash.xxHash" Version="1.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Ini">
+        <Version>1.1.0</Version>
+      </PackageReference>
       <PackageReference Include="MySql.Data" Version="8.0.24" />
       <PackageReference Include="NetTopologySuite" Version="2.2.0" />
       <PackageReference Include="NetTopologySuite.CoordinateSystems" Version="1.15.3" />

--- a/Services/Library/SmsPaymentService/SmsPaymentDTOFactory.cs
+++ b/Services/Library/SmsPaymentService/SmsPaymentDTOFactory.cs
@@ -9,7 +9,8 @@ namespace SmsPaymentService
     {
         public SmsPaymentDTO CreateSmsPaymentDTO(SmsPayment smsPayment, Order order)
         {
-            var newSmsPaymentDTO = new SmsPaymentDTO {
+            var newSmsPaymentDTO = new SmsPaymentDTO
+            {
                 Recepient = smsPayment.Recepient.Name,
                 RecepientId = smsPayment.Recepient.Id,
                 PhoneNumber = smsPayment.PhoneNumber,
@@ -18,18 +19,52 @@ namespace SmsPaymentService
                 PaymentCreationDate = smsPayment.CreationDate,
                 Amount = smsPayment.Amount,
                 RecepientType = smsPayment.Recepient.PersonType,
-                Items = new List<SmsPaymentItemDTO>()
+                Items = GetCalculatedSmsPaymentItemDTOs(order.OrderItems)
             };
 
-            foreach(var orderItem in order.OrderItems) {
-                newSmsPaymentDTO.Items.Add(new SmsPaymentItemDTO {
-                    Name = orderItem.Nomenclature.OfficialName,
-                    Quantity = orderItem.CurrentCount,
-                    Price = orderItem.Sum / orderItem.Count
-                });
+            return newSmsPaymentDTO;
+        }
+
+        private List<SmsPaymentItemDTO> GetCalculatedSmsPaymentItemDTOs(IList<OrderItem> itemList)
+        {
+            List<SmsPaymentItemDTO> smsPaymentDTOList = new List<SmsPaymentItemDTO>();
+
+            foreach (var item in itemList)
+            {
+                decimal price = decimal.Round(item.Sum / item.Count, 2, MidpointRounding.AwayFromZero);
+                bool isDevided = item.Sum == price * item.Count;
+
+                if (isDevided)
+                {
+                    smsPaymentDTOList.Add(
+                        new SmsPaymentItemDTO()
+                        {
+                            Name = item.Nomenclature.OfficialName,
+                            Quantity = item.CurrentCount,
+                            Price = price
+                        });
+                }
+                else
+                {
+                    smsPaymentDTOList.Add(
+                        new SmsPaymentItemDTO()
+                        {
+                            Name = item.Nomenclature.OfficialName,
+                            Quantity = item.CurrentCount - 1,
+                            Price = price
+                        });
+
+                    smsPaymentDTOList.Add(
+                        new SmsPaymentItemDTO()
+                        {
+                            Name = item.Nomenclature.OfficialName,
+                            Quantity = 1,
+                            Price = item.Sum - (price * (item.Count - 1))
+                        });
+                }
             }
 
-            return newSmsPaymentDTO;
+            return smsPaymentDTOList;
         }
     }
 }

--- a/VodovozBusinessTests/SmsPaymentService/SmsPaymentItemDTOCalculateTests.cs
+++ b/VodovozBusinessTests/SmsPaymentService/SmsPaymentItemDTOCalculateTests.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using NUnit.Framework;
+using SmsPaymentService;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NSubstitute;
+using Vodovoz.Domain;
+using Vodovoz.Domain.Client;
+using Vodovoz.Domain.Goods;
+using Vodovoz.Domain.Orders;
+
+namespace VodovozBusinessTests.SmsPaymentService
+{
+    [TestFixture]
+    public class SmsPaymentItemDTOCalculateTests
+    {
+        static IEnumerable OrdersTestSource()
+        {
+            yield return new Order
+            {
+                OrderItems = new List<OrderItem>
+                    {
+                        // (3*150-50)/3 = 133,3333333333333
+                        new OrderItem {Count = 3, Price = 150, DiscountMoney = 50, Nomenclature = new Nomenclature()},
+                        // (5*100)/5 = 100
+                        new OrderItem {Count = 5, Price = 100, Nomenclature = new Nomenclature()}
+                    }
+            };
+
+            yield return new Order
+            {
+                OrderItems = new List<OrderItem>
+                    {
+                        // (12*420-340)/12 = 391,6666666666667
+                        new OrderItem {Count = 12, Price = 420, DiscountMoney = 340, Nomenclature = new Nomenclature()}
+                    }
+            };
+
+            yield return new Order
+            {
+                OrderItems = new List<OrderItem>
+                    {
+                        // (7*200-400)/7 = 142,8571428571429
+                        new OrderItem {Count = 7, Price = 200, DiscountMoney = 400, Nomenclature = new Nomenclature()},
+                        // (11*50-50)/11 = 45,45454545454545
+                        new OrderItem {Count = 11, Price = 50, DiscountMoney = 50, Nomenclature = new Nomenclature()},
+                        // (3*500-500)/3 = 333,3333333333333
+                        new OrderItem {Count = 3, Price = 500, DiscountMoney = 500, Nomenclature = new Nomenclature()},
+                        // (4*120-10)/4 = 117,5
+                        new OrderItem {Count = 4, Price = 120, DiscountMoney = 10, Nomenclature = new Nomenclature()},
+                        // (8*500)/8 = 500
+                        new OrderItem {Count = 8, Price = 500, Nomenclature = new Nomenclature()}
+                    }
+            };
+        }
+
+        [Test(Description = "Сумма распределённых по номенклатурам цен*количество равна сумме заказа")]
+        [TestCaseSource(nameof(OrdersTestSource))]
+        public void SmsPaymentItemsPriceSum_EqualOrderSum(Order order)
+        {
+            // arrange
+
+            SmsPaymentDTOFactory smsPaymentDTOFactory = new SmsPaymentDTOFactory();
+            var smsPaymentMock = Substitute.For<SmsPayment>();
+
+            // act
+
+            var smsPaymentDTO = smsPaymentDTOFactory.CreateSmsPaymentDTO(smsPaymentMock, order);
+            var result = smsPaymentDTO.Items.Sum(x => x.Price * x.Quantity);
+
+            // assert
+
+            Assert.That(result, Is.EqualTo(order.TotalSum));
+        }
+
+        [Test(Description = "Распределение цен по номенклатурам (число без дроби)")]
+        public void SmsPaymentPriceForNomenclatureDistributions_WithoutFraction()
+        {
+            // arrange
+
+            SmsPaymentDTOFactory smsPaymentDTOFactory = new SmsPaymentDTOFactory();
+            var smsPaymentMock = Substitute.For<SmsPayment>();
+            var orderMock = Substitute.For<Order>();
+            orderMock.OrderItems = new List<OrderItem>
+            {
+                new OrderItem {Count = 3, Price = 300, Nomenclature = new Nomenclature()},
+            };
+
+            // act
+
+            var smsPaymentDTO = smsPaymentDTOFactory.CreateSmsPaymentDTO(smsPaymentMock, orderMock);
+
+            // assert
+
+            Assert.That(smsPaymentDTO.Items.Count, Is.EqualTo(1));
+
+            Assert.That(smsPaymentDTO.Items[0].Price, Is.EqualTo(300));
+            Assert.That(smsPaymentDTO.Items[0].Quantity, Is.EqualTo(3));
+        }
+
+        [Test(Description = "Распределение цен по номенклатурам (число с округляемой к меньшему периодической дробью 133.33333...)")]
+        public void SmsPaymentPriceForNomenclatureDistributions_WithCirculatingFraction_Down()
+        {
+            // arrange
+
+            SmsPaymentDTOFactory smsPaymentDTOFactory = new SmsPaymentDTOFactory();
+            var smsPaymentMock = Substitute.For<SmsPayment>();
+            var orderMock = Substitute.For<Order>();
+            orderMock.OrderItems = new List<OrderItem>
+            {
+                new OrderItem {Count = 3, Price = 150, DiscountMoney = 50, Nomenclature = new Nomenclature()}
+            };
+
+            // act
+
+            var smsPaymentDTO = smsPaymentDTOFactory.CreateSmsPaymentDTO(smsPaymentMock, orderMock);
+
+            // assert
+
+            Assert.That(smsPaymentDTO.Items.Count, Is.EqualTo(2));
+
+            Assert.That(smsPaymentDTO.Items[0].Price, Is.EqualTo(133.33));
+            Assert.That(smsPaymentDTO.Items[0].Quantity, Is.EqualTo(2));
+
+            Assert.That(smsPaymentDTO.Items[1].Price, Is.EqualTo(133.34));
+            Assert.That(smsPaymentDTO.Items[1].Quantity, Is.EqualTo(1));
+        }
+
+        [Test(Description = "Распределение цен по номенклатурам (число с округляемой к большему периодической дробью 142.857142857142...)")]
+        public void SmsPaymentPriceForNomenclatureDistributions_WithCirculatingFraction_Up()
+        {
+            // arrange
+
+            SmsPaymentDTOFactory smsPaymentDTOFactory = new SmsPaymentDTOFactory();
+            var smsPaymentMock = Substitute.For<SmsPayment>();
+            var orderMock = Substitute.For<Order>();
+            orderMock.OrderItems = new List<OrderItem>
+            {
+                new OrderItem {Count = 7, Price = 200, DiscountMoney = 400, Nomenclature = new Nomenclature()},
+            };
+
+            // act
+
+            var smsPaymentDTO = smsPaymentDTOFactory.CreateSmsPaymentDTO(smsPaymentMock, orderMock);
+
+            // assert
+
+            Assert.That(smsPaymentDTO.Items.Count, Is.EqualTo(2));
+
+            Assert.That(smsPaymentDTO.Items[0].Price, Is.EqualTo(142.86));
+            Assert.That(smsPaymentDTO.Items[0].Quantity, Is.EqualTo(6));
+
+            Assert.That(smsPaymentDTO.Items[1].Price, Is.EqualTo(142.84));
+            Assert.That(smsPaymentDTO.Items[1].Quantity, Is.EqualTo(1));
+        }
+    }
+}

--- a/VodovozBusinessTests/VodovozBusinessTests.csproj
+++ b/VodovozBusinessTests/VodovozBusinessTests.csproj
@@ -92,8 +92,13 @@
     <Compile Include="Domain\WageCalculation\CalculationServices\RouteList\AdvancedWageParameters\DeliveryTimeAdvancedWageParameterTest.cs" />
     <Compile Include="ErrorReporting\DefaultErrorMessageModelTest.cs" />
     <Compile Include="ErrorReporting\SingletonErrorReporterTest.cs" />
+    <Compile Include="SmsPaymentService\SmsPaymentItemDTOCalculateTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Services\Library\SmsPaymentService\SmsPaymentService.csproj">
+      <Project>{EFE73102-83BC-4036-8642-D3A4121E8351}</Project>
+      <Name>SmsPaymentService</Name>
+    </ProjectReference>
     <ProjectReference Include="..\VodovozBusiness\VodovozBusiness.csproj">
       <Project>{022DD59D-0EEE-420F-9750-EB275772F56A}</Project>
       <Name>VodovozBusiness</Name>


### PR DESCRIPTION
Такие проблемы возникают из-за того что в кассу нельзя отправить скидку. Подробное описание проблемы:

Допустим у нас в программе в заказе 3 бутыля по 150 рублей и скидка 50 рублей. Сумма: 3 * 150 - 50 = 400 рублей.

Когда мы посылаем данные в кассу мы должны послать итоговую сумму (400р) а также сумму каждой номенклатуры без скидок. Используемая сейчас формула для каждой номенклатуры: 400 / 3 = 133.33 и 3 в периоде

3 в периоде никуда не записать и она отпадает, из-за этого когда касса сама пытается посчитать итоговую сумму (она это делает) она получает: 133 * 3 = 399.99.

Исправление заключается в следующем:
Сначала проверяем, есть ли у нас проблемная позиция, для этого итоговая сумма по номенклатуре делится на количество и округляется до копеек, затем обратно умножается на количество. Если полученное значение не совпадает с суммой, то номенклатура является проблемной. (Пример 400/3=133,33. Обратно 133,33 * 3 != 400)

В этом случае мы делим позицию с проблемной номенклатурой для чека на две позиции. В первой позиции количество будет равняться n-1 по цене равной сумме номенклатуры делённой на количество. Цена второй позиции с количеством равном единице будет равна оставшейся сумме (сумма номенклатуры минус ((n-1) * сумма номенклатуры/количество). Её запоминаем.

Если в заказе есть ещё проблемные номенклатуры, то остатки от деления будут добавляться уже к запомненной выше позиции чека.

Пример: 

Вода 19 л "Весёлый водовоз PREMIUM Кислородная"
    2 x 133,33 RUB НДС по ставке 0%        266,66

Вода 19 л "Весёлый водовоз PREMIUM Кислородная"
    1 x 133,34 RUB НДС по ставке 0%        133,34

                Всего:        400 RUB