### PR TITLE
3381 Оборудование перенесенных заказов в таблице расхождений

### DIFF
--- a/VodovozBusiness/Domain/Logistic/RouteList.cs
+++ b/VodovozBusiness/Domain/Logistic/RouteList.cs
@@ -770,7 +770,7 @@ namespace Vodovoz.Domain.Logistic
 			}
 
 			//ОБОРУДОВАНИЕ
-			var orderEquipments = Addresses.Where(item => item.TransferedTo == null || item.TransferedTo.NeedToReload)
+			var orderEquipments = Addresses.Where(item => item.TransferedTo == null)
 									   .SelectMany(item => item.Order.OrderEquipments)
 									   .Where(item => Nomenclature.GetCategoriesForShipment().Contains(item.Nomenclature.Category))
 									   .ToList();


### PR DESCRIPTION
Ранее в диалоге отображалось оборудование, если заказ был перенесен в другой МЛ с необходимостью повторной загрузки (NeedToReload). Убрал эту проверку согласно описанию задачи