### PR TITLE
3508 - Перенос скидки на доставку при создании заказа из недовоза

### DIFF
--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -2072,7 +2072,19 @@ namespace Vodovoz.Domain.Orders
 				};
 				AddOrderItem(newItem);
 			}
+
 			RecalculateItemsPrice();
+
+			//Перенос скидки на доставку
+			var deliveryOrderItemFrom = order.OrderItems.FirstOrDefault(x => x.Nomenclature.Id == PaidDeliveryNomenclatureId);
+			var deliveryOrderItemTo = OrderItems.FirstOrDefault(x => x.Nomenclature.Id == PaidDeliveryNomenclatureId);
+			if (deliveryOrderItemFrom != null && deliveryOrderItemTo != null)
+			{
+				deliveryOrderItemTo.IsDiscountInMoney = deliveryOrderItemFrom.IsDiscountInMoney;
+				deliveryOrderItemTo.DiscountMoney = deliveryOrderItemFrom.DiscountMoney;
+				deliveryOrderItemTo.Discount = deliveryOrderItemFrom.Discount;
+				deliveryOrderItemTo.DiscountReason = deliveryOrderItemFrom.DiscountReason ?? deliveryOrderItemFrom.OriginalDiscountReason;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
При создании заказа из диалога отмены заказа (подтвердить заказ -> отменить заказ -> создать новый заказ из диалога отмены заказа) в заказ не переносилась скидка на доставку (доставка пересчитывается в CalculateDeliveryPrice() при любом изменении в ObservableOrderItems, и когда мы добавляем какую-либо номенклатуру, добавляется/пересчитывается/удаляется доставка, с-но скидка пропадает). Менять что-либо внутри логики пересчёта стоимости доставки специально для случая формирования заказа из недовоза не стал, просто переношу скидку на доставку из недовоза в конце метода копирования номенклатур. 