### PR TITLE
Задача 3576: Ограничение возможности изменения параметров автомобиля

### DIFF
--- a/Vodovoz/Dialogs/Logistic/CarsDlg.cs
+++ b/Vodovoz/Dialogs/Logistic/CarsDlg.cs
@@ -142,7 +142,11 @@ namespace Vodovoz
 			textDriverInfo.Selectable = true;
 
 			int currentUserId = ServicesConfig.CommonServices.UserService.CurrentUserId;
-			bool canChangeVolumeWeightConsumption = ServicesConfig.CommonServices.PermissionService.ValidateUserPresetPermission("can_change_cars_volume_weight_consumption", currentUserId) || Entity.Id == 0 || !Entity.IsCompanyCar;
+			bool canChangeVolumeWeightConsumption = 
+				ServicesConfig.CommonServices.PermissionService.ValidateUserPresetPermission("can_change_cars_volume_weight_consumption", currentUserId)
+				|| Entity.Id == 0
+				|| !(Entity.IsCompanyCar || Entity.IsRaskat);
+
 			bool canChangeBottlesFromAddress = ServicesConfig.CommonServices.PermissionService.ValidateUserPresetPermission("can_change_cars_bottles_from_address", currentUserId);
 
 			dataspinbutton1.Sensitive = canChangeVolumeWeightConsumption;


### PR DESCRIPTION
Для изменения параметров:
- Грузоподъёмность
- Объём груза
- Расход топлива

У раскатных автомобилей теперь требуется наличие права "Изменение в автомобиле расхода топлива, объема груза, грузоподъемности"