### PR TITLE
Еще одна проверка на длину имени файла в рекламациях

### DIFF
--- a/VodovozViewModels/ViewModels/Complaints/ComplaintDiscussionViewModel.cs
+++ b/VodovozViewModels/ViewModels/Complaints/ComplaintDiscussionViewModel.cs
@@ -60,7 +60,7 @@ namespace Vodovoz.ViewModels.Complaints
 		public FilesViewModel FilesViewModel {
 			get {
 				if(filesViewModel == null) {
-					filesViewModel = new FilesViewModel(filePickerService, UoW);
+					filesViewModel = new FilesViewModel(filePickerService, commonServices.InteractiveService, UoW);
 					filesViewModel.FilesList = NewCommentFiles;
 				}
 


### PR DESCRIPTION
Добавил проверку на длину имени файла при добавлении комментария в ответственном подразделении. Возможно уйдет и вторая ошибка Session.IsClosed