### PR TITLE
Фикс пустых OrderItems в заказе

### DIFF
--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using fyiReporting.RDL;
 using Gamma.Utilities;
+using NHibernate;
 using NHibernate.Exceptions;
 using QS.Dialog;
 using QS.DomainModel.Entity;
@@ -361,13 +362,13 @@ namespace Vodovoz.Domain.Orders
 			set => SetField(ref shipped, value, () => Shipped);
 		}
 
-		PaymentType paymentType;
+		PaymentType _paymentType;
 
 		[Display(Name = "Форма оплаты")]
 		public virtual PaymentType PaymentType {
-			get => paymentType;
+			get => _paymentType;
 			set {
-				if(value != paymentType && SetField(ref paymentType, value, () => PaymentType)) {
+				if(value != _paymentType && SetField(ref _paymentType, value, () => PaymentType)) {
 					switch (PaymentType) {
 						case PaymentType.cash:
 						case PaymentType.barter:
@@ -478,12 +479,12 @@ namespace Vodovoz.Domain.Orders
 			set => SetField(ref tareNonReturnReason, value, () => TareNonReturnReason);
 		}
 
-		PaymentFrom paymentByCardFrom;
+		PaymentFrom _paymentByCardFrom;
 		[Display(Name = "Место, откуда проведена оплата")]
 		public virtual PaymentFrom PaymentByCardFrom {
-			get => paymentByCardFrom;
+			get => _paymentByCardFrom;
 			set {
-				if(SetField(ref paymentByCardFrom, value, () => PaymentByCardFrom)) {
+				if(SetField(ref _paymentByCardFrom, value, () => PaymentByCardFrom)) {
 					UpdateContract();
 				}
 			}
@@ -1288,14 +1289,24 @@ namespace Vodovoz.Domain.Orders
 		private IOrganizationProvider orderOrganizationProvider;
 		private CounterpartyContractRepository counterpartyContractRepository;
 		private CounterpartyContractFactory counterpartyContractFactory;
-		
+
+		/// <summary>
+		/// <b>Не должен вызываться при создании сущности NHibernate'ом</b>
+		/// </summary>
 		private void UpdateContract(bool onPaymentTypeChanged = false)
 		{
-			NHibernate.NHibernateUtil.Initialize(Client);
-			NHibernate.NHibernateUtil.Initialize(Contract);
-
-			if(!NHibernate.NHibernateUtil.IsInitialized(Client)
-			   || !NHibernate.NHibernateUtil.IsInitialized(Contract)) {
+			//Если Initialize вызывается при создании сущности NHibernate'ом,
+			//то почему-то не загружаются OrderItems и OrderDocuments (А возможно и вообще все коллекции Order)
+			if(!NHibernateUtil.IsInitialized(Client))
+			{
+				NHibernateUtil.Initialize(Client);
+			}
+			if(!NHibernateUtil.IsInitialized(Contract))
+			{
+				NHibernateUtil.Initialize(Contract);
+			}
+			if(!NHibernateUtil.IsInitialized(Client) || !NHibernateUtil.IsInitialized(Contract))
+			{
 				return;
 			}
 			

--- a/VodovozBusiness/HibernateMapping/Order/OrderMap.cs
+++ b/VodovozBusiness/HibernateMapping/Order/OrderMap.cs
@@ -1,4 +1,5 @@
-﻿using FluentNHibernate.Mapping;
+﻿using FluentNHibernate;
+using FluentNHibernate.Mapping;
 using Vodovoz.Domain.Client;
 using Vodovoz.Domain.Orders;
 
@@ -11,88 +12,103 @@ namespace Vodovoz.HibernateMapping
 			Table("orders");
 
 			OptimisticLock.Version();
-			Version(x => x.Version)						.Column("version");
+			Version(x => x.Version)                       .Column("version");
 
-			Id(x => x.Id)								.Column("id").GeneratedBy.Native();
+			Id(x => x.Id)                                 .Column("id").GeneratedBy.Native();
 
-			Map(x => x.CreateDate)					.Column("create_date").ReadOnly();
-			Map(x => x.IsFirstOrder)					.Column("is_first_order");
-			Map(x => x.Comment)							.Column("comment");
-			Map(x => x.CommentLogist)					.Column("comment_logist");
-			Map(x => x.DeliveryDate)					.Column("delivery_date");
-			Map(x => x.SelfDelivery)					.Column("self_delivery");
-			Map(x => x.PayAfterShipment)				.Column("pay_after_shipment");
-			Map(x => x.BottlesReturn)					.Column("bottles_return");
-			Map(x => x.ExtraMoney)						.Column("extra_money");
-			Map(x => x.OrderCashSum)					.Column("sum_to_receive");
-			Map(x => x.Shipped)							.Column("shipped");
-			Map(x => x.SumDifferenceReason)				.Column("sum_difference_reason");
-			Map(x => x.CollectBottles)					.Column("collect_bottles");
-			Map(x => x.Code1c)							.Column("code1c");
-			Map(x => x.Address1c)						.Column("address_1c");
-			Map(x => x.Address1cCode)					.Column("address_1c_code");
-			Map(x => x.DeliverySchedule1c)				.Column("delivery_schedule_1c");
-			Map(x => x.DailyNumber)						.Column("daily_number_1c").ReadOnly();
-			Map(x => x.ClientPhone)						.Column("client_phone");
-			Map(x => x.LastEditedTime)					.Column("last_edited_time");
-			Map(x => x.CommentManager)					.Column("comment_manager");
-			Map(x => x.ReturnedTare)					.Column("returned_tare");
-			Map(x => x.InformationOnTara)				.Column("information_on_tara");
-			Map(x => x.OnRouteEditReason)				.Column("on_route_edit_reason");
-			Map(x => x.DriverCallId)					.Column("driver_call_id");
-			Map(x => x.IsService)						.Column("service");
-			Map(x => x.Trifle)							.Column("trifle");
-			Map(x => x.OnlineOrder)						.Column("online_order");
-			Map(x => x.ToClientText)					.Column("to_client_text");
-			Map(x => x.FromClientText)					.Column("from_client_text");
-			Map(x => x.IsContractCloser)				.Column("is_contract_closer");
-			Map(x => x.IsSelfDeliveryPaid)              .Column("is_self_delivery_paid");
-			Map(x => x.BillDate)						.Column("bill_date");
+			Map(x => x.CreateDate)                        .Column("create_date").ReadOnly();
+			Map(x => x.IsFirstOrder)                      .Column("is_first_order");
+			Map(x => x.Comment)                           .Column("comment");
+			Map(x => x.CommentLogist)                     .Column("comment_logist");
+			Map(x => x.DeliveryDate)                      .Column("delivery_date");
+			Map(x => x.SelfDelivery)                      .Column("self_delivery");
+			Map(x => x.PayAfterShipment)                  .Column("pay_after_shipment");
+			Map(x => x.BottlesReturn)                     .Column("bottles_return");
+			Map(x => x.ExtraMoney)                        .Column("extra_money");
+			Map(x => x.OrderCashSum)                      .Column("sum_to_receive");
+			Map(x => x.Shipped)                           .Column("shipped");
+			Map(x => x.SumDifferenceReason)               .Column("sum_difference_reason");
+			Map(x => x.CollectBottles)                    .Column("collect_bottles");
+			Map(x => x.Code1c)                            .Column("code1c");
+			Map(x => x.Address1c)                         .Column("address_1c");
+			Map(x => x.Address1cCode)                     .Column("address_1c_code");
+			Map(x => x.DeliverySchedule1c)                .Column("delivery_schedule_1c");
+			Map(x => x.DailyNumber)                       .Column("daily_number_1c").ReadOnly();
+			Map(x => x.ClientPhone)                       .Column("client_phone");
+			Map(x => x.LastEditedTime)                    .Column("last_edited_time");
+			Map(x => x.CommentManager)                    .Column("comment_manager");
+			Map(x => x.ReturnedTare)                      .Column("returned_tare");
+			Map(x => x.InformationOnTara)                 .Column("information_on_tara");
+			Map(x => x.OnRouteEditReason)                 .Column("on_route_edit_reason");
+			Map(x => x.DriverCallId)                      .Column("driver_call_id");
+			Map(x => x.IsService)                         .Column("service");
+			Map(x => x.Trifle)                            .Column("trifle");
+			Map(x => x.OnlineOrder)                       .Column("online_order");
+			Map(x => x.ToClientText)                      .Column("to_client_text");
+			Map(x => x.FromClientText)                    .Column("from_client_text");
+			Map(x => x.IsContractCloser)                  .Column("is_contract_closer");
+			Map(x => x.IsSelfDeliveryPaid)                .Column("is_self_delivery_paid");
+			Map(x => x.BillDate)                          .Column("bill_date");
 			Map(x => x.IsTareNonReturnReasonChangedByUser).Column("is_reason_type_changed_by_user");
-			Map(x => x.HasCommentForDriver)				.Column("has_comment_for_driver");
-			Map(x => x.TimeDelivered)               	.Column("time_delivered");
-			Map(x => x.AddCertificates)					.Column("add_certificates");
-			Map(x => x.IsBottleStock)					.Column("is_bottle_stock");
-			Map(x => x.BottlesByStockCount)				.Column("bottles_by_stock_count");
-			Map(x => x.BottlesByStockActualCount)		.Column("bottles_by_stock_actual_count");
-			Map(x => x.EShopOrder)						.Column("e_shop_order");
-			Map(x => x.ContactlessDelivery)				.Column("contactless_delivery");
-			Map(x => x.PaymentBySms)				    .Column("payment_by_sms");
-			Map(x => x.ODZComment)						.Column("odz_comment");
-			Map(x => x.OPComment)						.Column("op_comment");
-			
-			Map(x => x.OrderStatus)						.Column("order_status").CustomType<OrderStatusStringType> ();
-			Map(x => x.SignatureType)					.Column("signature_type").CustomType<OrderSignatureTypeStringType> ();
-			Map(x => x.PaymentType)						.Column("payment_type").CustomType<PaymentTypeStringType> ();
-			Map(x => x.DocumentType)					.Column("document_type").CustomType<DefaultDocumentTypeStringType> ();
-			Map(x => x.DriverCallType)					.Column("driver_call_type").CustomType<DriverCallTypeStringType>();
-			Map(x => x.OrderSource)						.Column("order_source").CustomType<OrderSourceStringType>();
-			Map(x => x.OrderPaymentStatus)				.Column("order_payment_status").CustomType<OrderPaymentStatusStringType>();
+			Map(x => x.HasCommentForDriver)               .Column("has_comment_for_driver");
+			Map(x => x.TimeDelivered)                     .Column("time_delivered");
+			Map(x => x.AddCertificates)                   .Column("add_certificates");
+			Map(x => x.IsBottleStock)                     .Column("is_bottle_stock");
+			Map(x => x.BottlesByStockCount)               .Column("bottles_by_stock_count");
+			Map(x => x.BottlesByStockActualCount)         .Column("bottles_by_stock_actual_count");
+			Map(x => x.EShopOrder)                        .Column("e_shop_order");
+			Map(x => x.ContactlessDelivery)               .Column("contactless_delivery");
+			Map(x => x.PaymentBySms)                      .Column("payment_by_sms");
+			Map(x => x.ODZComment)                        .Column("odz_comment");
+			Map(x => x.OPComment)                         .Column("op_comment");
 
-			References(x => x.Client)					.Column("client_id");
-			References(x => x.Contract)					.Column("counterparty_contract_id").Cascade.SaveUpdate();
-			References(x => x.Author)					.Column("author_employee_id");
-			References(x => x.AcceptedOrderEmployee)	.Column("accepted_order_employee");
-			References(x => x.DeliveryPoint)			.Column("delivery_point_id");
-			References(x => x.DeliverySchedule)			.Column("delivery_schedule_id");
-			References(x => x.PreviousOrder)			.Column("previous_order_id");
-			References(x => x.BottlesMovementOperation) .Column("bottles_movement_operation_id");
-			References(x => x.MoneyMovementOperation)	.Column("money_movement_operation_id");
-			References(x => x.LastEditor)				.Column("editor_employee_id");
-			References(x => x.LoadAllowedBy)			.Column("load_allowed_employee_id");
-			References(x => x.TareNonReturnReason)		.Column("tare_non_return_reason_id");
-			References(x => x.PaymentByCardFrom)		.Column("payment_from_id");
-			References(x => x.ReturnTareReason).Column("return_tare_reason_id");
-			References(x => x.ReturnTareReasonCategory).Column("return_tare_reason_category_id");
+			Map(x => x.OrderStatus)                       .Column("order_status")
+				.CustomType<OrderStatusStringType>();
+			Map(x => x.SignatureType)                     .Column("signature_type")
+				.CustomType<OrderSignatureTypeStringType>();
+			Map(x => x.PaymentType)                       .Column("payment_type")
+				.CustomType<PaymentTypeStringType>()
+				.Access.CamelCaseField(Prefix.Underscore);
+			Map(x => x.DocumentType)                      .Column("document_type")
+				.CustomType<DefaultDocumentTypeStringType>();
+			Map(x => x.DriverCallType)                    .Column("driver_call_type")
+				.CustomType<DriverCallTypeStringType>();
+			Map(x => x.OrderSource)                       .Column("order_source")
+				.CustomType<OrderSourceStringType>();
+			Map(x => x.OrderPaymentStatus)                .Column("order_payment_status")
+				.CustomType<OrderPaymentStatusStringType>();
 
-			HasMany(x => x.OrderDocuments)		.Cascade.AllDeleteOrphan  ().Inverse ().LazyLoad ().KeyColumn ("attached_to_order_id");
-			HasMany (x => x.OrderDepositItems)	.Cascade.AllDeleteOrphan  ().Inverse ().LazyLoad ().KeyColumn ("order_id");
-			HasMany (x => x.OrderItems)			.Cascade.AllDeleteOrphan  ().Inverse ().LazyLoad ().KeyColumn ("order_id");
-			HasMany (x => x.OrderEquipments)	.Cascade.AllDeleteOrphan  ().Inverse ().LazyLoad ().KeyColumn ("order_id");
-			HasMany (x => x.InitialOrderService).Cascade.None 			  ().Inverse ().LazyLoad ().KeyColumn ("initial_order_id");
-			HasMany (x => x.FinalOrderService)	.Cascade.None  			  ().Inverse ().LazyLoad ().KeyColumn ("final_order_id");
-			HasMany (x => x.DepositOperations)  .Cascade.AllDeleteOrphan  ().Inverse ().LazyLoad ().KeyColumn ("order_id");
-			
+			References(x => x.Client)                     .Column("client_id");
+			References(x => x.Contract)                   .Column("counterparty_contract_id").Cascade.SaveUpdate();
+			References(x => x.Author)                     .Column("author_employee_id");
+			References(x => x.AcceptedOrderEmployee)      .Column("accepted_order_employee");
+			References(x => x.DeliveryPoint)              .Column("delivery_point_id");
+			References(x => x.DeliverySchedule)           .Column("delivery_schedule_id");
+			References(x => x.PreviousOrder)              .Column("previous_order_id");
+			References(x => x.BottlesMovementOperation)   .Column("bottles_movement_operation_id");
+			References(x => x.MoneyMovementOperation)     .Column("money_movement_operation_id");
+			References(x => x.LastEditor)                 .Column("editor_employee_id");
+			References(x => x.LoadAllowedBy)              .Column("load_allowed_employee_id");
+			References(x => x.TareNonReturnReason)        .Column("tare_non_return_reason_id");
+			References(x => x.PaymentByCardFrom)          .Column("payment_from_id").Access.CamelCaseField(Prefix.Underscore);
+			References(x => x.ReturnTareReason)           .Column("return_tare_reason_id");
+			References(x => x.ReturnTareReasonCategory)   .Column("return_tare_reason_category_id");
+
+			HasMany(x => x.OrderDocuments)                .KeyColumn("attached_to_order_id")
+				.Cascade.AllDeleteOrphan().Inverse().LazyLoad();
+			HasMany(x => x.OrderDepositItems)             .KeyColumn("order_id")
+				.Cascade.AllDeleteOrphan().Inverse().LazyLoad();
+			HasMany(x => x.OrderItems)                    .KeyColumn("order_id")
+				.Cascade.AllDeleteOrphan().Inverse().LazyLoad();
+			HasMany(x => x.OrderEquipments)               .KeyColumn("order_id")
+				.Cascade.AllDeleteOrphan().Inverse().LazyLoad();
+			HasMany(x => x.InitialOrderService)           .KeyColumn("initial_order_id").
+				Cascade.None().Inverse().LazyLoad();
+			HasMany(x => x.FinalOrderService)             .KeyColumn("final_order_id")
+				.Cascade.None().Inverse().LazyLoad();
+			HasMany(x => x.DepositOperations)             .KeyColumn("order_id")
+				.Cascade.AllDeleteOrphan().Inverse().LazyLoad();
+
 			HasManyToMany(x => x.PromotionalSets)
 				.Table("promotional_sets_to_orders")
 				.ParentKeyColumn("order_id")


### PR DESCRIPTION
Переделал маппинг некоторых свойств заказа таким образом, что при создании сущности NHibernate'ом не вызываются их сеттеры. Раньше они вызывались, далее вызывался NHibernateUtil.Initialize(Client), который почему-то отключает загрузку всех коллекций заказа, если запускается во время создания сущности.
Переформатировал код в OrderMap