### PR TITLE
3489 Поиск в виджетах журнала изменений без учета регистра

### DIFF
--- a/VodovozViewModels/Journals/JournalViewModels/HistoryTrace/HistoryTraceObjectJournalViewModel.cs
+++ b/VodovozViewModels/Journals/JournalViewModels/HistoryTrace/HistoryTraceObjectJournalViewModel.cs
@@ -49,7 +49,9 @@ namespace Vodovoz.ViewModels.Journals.JournalViewModels.HistoryTrace
             {
                 foreach (var searchValue in Search.SearchValues)
                 {
-                    result = result.Where(n => n.DisplayName.Contains(searchValue)|| n.ObjectType.ToString().Contains(searchValue));
+	                const StringComparison caseInsensitive = StringComparison.CurrentCultureIgnoreCase;
+	                result = result.Where(n => n.DisplayName.IndexOf(searchValue, caseInsensitive) > -1
+	                                           || n.ObjectType.ToString().IndexOf(searchValue, caseInsensitive) > -1);
                 }
             }
 

--- a/VodovozViewModels/Journals/JournalViewModels/HistoryTrace/HistoryTracePropertyJournalViewModel.cs
+++ b/VodovozViewModels/Journals/JournalViewModels/HistoryTrace/HistoryTracePropertyJournalViewModel.cs
@@ -60,7 +60,7 @@ namespace Vodovoz.ViewModels.Journals.JournalViewModels.HistoryTrace
                 {
                     foreach (var searchValue in Search.SearchValues)
                     {
-                        result = result.Where(n => n.PropertyName.Contains(searchValue));
+                        result = result.Where(n => n.PropertyName.IndexOf(searchValue, StringComparison.CurrentCultureIgnoreCase) > -1);
                     }
                 }
 


### PR DESCRIPTION
Судя по всему, касается только NodeViewModelEntry, которые есть только в журнале изменений, объект изменений и реквизит объекта.
Проверил некоторые другие entityVMentry:
- журнал перемещения ДС, выбор авто
- готовые к погрузке/разгрузке, выбор склада
- сотрудник, выбор подразделения
- отчет по километражу, выбор сотрудника и авто