### PR TITLE
3585 - Доработки отчёта Аналитика ТС

### DIFF
--- a/Vodovoz/Views/Reports/CarsExploitationReportView.cs
+++ b/Vodovoz/Views/Reports/CarsExploitationReportView.cs
@@ -113,7 +113,7 @@ namespace Vodovoz.Views.Reports
 			for(var i = 0; i < daysInMonth; i++)
 			{
 				var index = i;
-				columnsConfig.AddColumn($"День {i + 1}").AddTextRenderer(row => row.Days[index]);
+				columnsConfig.AddColumn($"День {i + 1}").AddTextRenderer(row => row.Days[index]).WrapWidth(35).WrapMode(Pango.WrapMode.WordChar);
 			}
 
 			ytreeReportIndicatorsRows.ColumnsConfig = columnsConfig.Finish();

--- a/Vodovoz/Views/Reports/CarsExploitationReportView.cs
+++ b/Vodovoz/Views/Reports/CarsExploitationReportView.cs
@@ -113,7 +113,7 @@ namespace Vodovoz.Views.Reports
 			for(var i = 0; i < daysInMonth; i++)
 			{
 				var index = i;
-				columnsConfig.AddColumn($"День {i + 1}").AddTextRenderer(row => row.Days[index]).WrapWidth(35).WrapMode(Pango.WrapMode.WordChar);
+				columnsConfig.AddColumn($"День { i + 1 }").AddTextRenderer(row => row.Days[index]).WrapWidth(35).WrapMode(Pango.WrapMode.WordChar);
 			}
 
 			ytreeReportIndicatorsRows.ColumnsConfig = columnsConfig.Finish();

--- a/VodovozViewModels/ViewModels/Reports/CarsExploitationReportViewModel.cs
+++ b/VodovozViewModels/ViewModels/Reports/CarsExploitationReportViewModel.cs
@@ -188,7 +188,7 @@ namespace Vodovoz.ViewModels.Reports
 
 			List<CarEvent> carEvents = null;
 
-			if(selectedIndicators.Contains(Indicator.CarEvent))
+			if(selectedIndicators.Contains(Indicator.CarEvents))
 			{
 				var carEventQuery = UoW.Session.Query<CarEvent>()
 					.Where(carEvent => carEvent.Car != null
@@ -255,6 +255,40 @@ namespace Vodovoz.ViewModels.Reports
 					}
 
 					rows.Add(newRow);
+				}
+
+				if(selectedIndicators.Contains(Indicator.CarEvents))
+				{
+					var newRow = new CarsExploitationReportRow()
+					{
+						AssignedDriver = rowDriverFullName,
+						CarOrderNumber = carItem.OrderNumber ?? 0,
+						CarOwnType = rowCarOwnType,
+						CarType = rowCompanyCarType,
+						Indicator = Indicator.CarEvents,
+						RegNumber = carItem.RegistrationNumber,
+						GeographicalGroups = rowGeoGroups,
+						Days = new string[daysInMonth]
+					};
+
+					for(var dayId = 0; dayId < daysInMonth; dayId++)
+					{
+						var dayCarEvent = carEvents
+							.Where(carEvent => carEvent.Car == carItem
+							                   && ((carEvent.StartDate <= startDate.AddDays(dayId) && carEvent.EndDate >= startDate.AddDays(dayId))))
+							.Select(x => x.CarEventType.ShortName);
+
+						if(dayCarEvent.Count() > 0)
+						{
+							newRow.Days[dayId] = string.Join(", ", dayCarEvent);
+						}
+
+					}
+
+					if(newRow.Days.Any(day => !string.IsNullOrEmpty(day)))
+					{
+						rows.Add(newRow);
+					}
 				}
 
 				if(selectedIndicators.Contains(Indicator.WageDistricts))
@@ -826,40 +860,6 @@ namespace Vodovoz.ViewModels.Reports
 						}
 					}
 				}
-
-				if(selectedIndicators.Contains(Indicator.CarEvent))
-				{
-					var newRow = new CarsExploitationReportRow()
-					{
-						AssignedDriver = rowDriverFullName,
-						CarOrderNumber = carItem.OrderNumber ?? 0,
-						CarOwnType = rowCarOwnType,
-						CarType = rowCompanyCarType,
-						Indicator = Indicator.CarEvent,
-						RegNumber = carItem.RegistrationNumber,
-						GeographicalGroups = rowGeoGroups,
-						Days = new string[daysInMonth]
-					};
-
-					for(var dayId = 0; dayId < daysInMonth; dayId++)
-					{
-						var dayCarEvent = carEvents
-							.Where(carEvent => carEvent.Car == carItem
-											   && ((carEvent.StartDate <= startDate.AddDays(dayId) && carEvent.EndDate >= startDate.AddDays(dayId))))
-							.Select(x => x.CarEventType.ShortName);
-
-						if(dayCarEvent.Count() > 0)
-						{
-							newRow.Days[dayId] = string.Join(",\n", dayCarEvent);
-						}
-
-					}
-
-					if(newRow.Days.Any(day => !string.IsNullOrEmpty(day)))
-					{
-						rows.Add(newRow);
-					}
-				}
 			}
 
 			result.Rows = rows;
@@ -1069,6 +1069,8 @@ namespace Vodovoz.ViewModels.Reports
 	{
 		[Display(Name = "Рейсы")]
 		Trips,
+		[Display(Name = "События ТС")]
+		CarEvents,
 		[Display(Name = "Город/Пригород")]
 		WageDistricts,
 		[Display(Name = "Км предп")]
@@ -1098,8 +1100,6 @@ namespace Vodovoz.ViewModels.Reports
 		[Display(Name = "кг")]
 		LoadingKilograms,
 		[Display(Name = "м3")]
-		LoadingCubicMeters,
-		[Display(Name = "События ТС")]
-		CarEvent
+		LoadingCubicMeters
 	}
 }


### PR DESCRIPTION
Добавлен перенос текста в ячейках с днями. "Событие ТС" в фильтре и таблице перемещено выше и теперь следует сразу за строкой "Рейсы".