### PR TITLE
3436 - В диалогах при отмене убран вопрос "Сохранить изменения перед закрытием", если изменения не производились

### DIFF
--- a/Vodovoz/Dialogs/DocumentDialogs/CarUnloadDocumentDlg.cs
+++ b/Vodovoz/Dialogs/DocumentDialogs/CarUnloadDocumentDlg.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.Bindings.Collections.Generic;
 using System.Linq;
 using QS.Dialog.GtkUI;
 using QS.DomainModel.Entity.EntityPermissions.EntityExtendedPermission;
@@ -42,9 +43,6 @@ namespace Vodovoz
 		private ICarUnloadRepository CarUnloadRepository => CarUnloadSingletonRepository.GetInstance();
 		private ITerminalNomenclatureProvider terminalNomenclatureProvider = new BaseParametersProvider();
 		IList<Equipment> alreadyUnloadedEquipment;
-
-		public override bool HasChanges => true;
-
 		private WageParameterService wageParameterService = new WageParameterService(WageSingletonRepository.GetInstance(), new BaseParametersProvider());
 		private CallTaskWorker callTaskWorker;
 
@@ -170,6 +168,12 @@ namespace Vodovoz
 			} else {
 				Entity.CanEdit = true;
 			}
+
+			spnTareToReturn.ValueChanged += (sender, e) => HasChanges = true;
+			((GenericObservableList<ReceptionItemNode>)returnsreceptionview.Items).ListContentChanged += (sender, e) => HasChanges = true;
+			((GenericObservableList<ReceptionNonSerialEquipmentItemNode>)nonserialequipmentreceptionview1.Items).ListContentChanged +=
+				(sender, e) => HasChanges = true;
+			((GenericObservableList<DefectiveItemNode>)defectiveitemsreceptionview1.Items).ListContentChanged += (sender, e) => HasChanges = true;
 		}
 
 		public override bool Save()

--- a/Vodovoz/Dialogs/DocumentDialogs/SelfDeliveryDocumentDlg.cs
+++ b/Vodovoz/Dialogs/DocumentDialogs/SelfDeliveryDocumentDlg.cs
@@ -38,8 +38,6 @@ namespace Vodovoz
 	{
 		static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 		
-		public override bool HasChanges => GoodsReceptionList.Sum(x => x.Amount) >= 0 || base.HasChanges;
-		
 		GenericObservableList<GoodsReceptionVMNode> GoodsReceptionList = new GenericObservableList<GoodsReceptionVMNode>();
 
 		public SelfDeliveryDocumentDlg()
@@ -203,6 +201,9 @@ namespace Vodovoz
 			}
 
 			FillTrees();
+
+			spnTareToReturn.ValueChanged += (sender, e) => HasChanges = true;
+			GoodsReceptionList.ListContentChanged += (sender, e) => HasChanges = true;
 		}
 
 		void FillTrees()

--- a/Vodovoz/Dialogs/Logistic/RouteListClosingDlg.cs
+++ b/Vodovoz/Dialogs/Logistic/RouteListClosingDlg.cs
@@ -126,7 +126,6 @@ namespace Vodovoz
 			PerformanceHelper.StartMeasurement();
 
 			UoWGeneric = UnitOfWorkFactory.CreateForRoot<RouteList>(routeListId);
-			this.HasChanges = true;
 
 			TabName = string.Format("Закрытие маршрутного листа №{0}", Entity.Id);
 			PerformanceHelper.AddTimePoint("Создан UoW");

--- a/Vodovoz/Dialogs/Logistic/RouteListMileageCheckDlg.cs
+++ b/Vodovoz/Dialogs/Logistic/RouteListMileageCheckDlg.cs
@@ -70,7 +70,6 @@ namespace Vodovoz
 
 		public void ConfigureDlg()
 		{
-			HasChanges = true;
 			if(!editing) {
 				MessageDialogHelper.RunWarningDialog("Не достаточно прав. Обратитесь к руководителю.");
 				HasChanges = false;

--- a/Vodovoz/Dialogs/SubdivisionDlg.cs
+++ b/Vodovoz/Dialogs/SubdivisionDlg.cs
@@ -24,8 +24,6 @@ namespace Vodovoz
 		SubdivisionsVM subdivisionsVM;
 		PresetSubdivisionPermissionsViewModel presetPermissionVM;
 
-		public override bool HasChanges { get => true; set { } }
-
 		[Obsolete("Использовать Vodovoz.Views.Organization.SubdivisionView")]
 		public SubdivisionDlg()
 		{
@@ -86,6 +84,10 @@ namespace Vodovoz
 			vboxPresetPermissions.Add(new PresetPermissionsView(presetPermissionVM));
 			vboxPresetPermissions.ShowAll();
 			vboxPresetPermissions.Visible = QSMain.User.Admin;
+
+			presetPermissionVM.ObservablePermissionsList.ListContentChanged += (sender, e) => HasChanges = true;
+			Entity.ObservableDocumentTypes.ListContentChanged += (sender, e) => HasChanges = true;
+			subdivisionentitypermissionwidget.ViewModel.ObservableTypeOfEntitiesList.ListContentChanged += (sender, e) => HasChanges = true;
 		}
 
 		void YSpecCmbGeographicGroup_ItemSelected(object sender, Gamma.Widgets.ItemSelectedEventArgs e)

--- a/VodovozBusiness/Domain/Documents/SelfDeliveryDocument.cs
+++ b/VodovozBusiness/Domain/Documents/SelfDeliveryDocument.cs
@@ -315,11 +315,18 @@ namespace Vodovoz.Domain.Documents
 		#endregion
 	}
 
-	public class GoodsReceptionVMNode
+	public class GoodsReceptionVMNode: PropertyChangedBase
 	{
 		public int NomenclatureId { get; set; }
 		public string Name { get; set; }
-		public decimal Amount { get; set; }
+
+		decimal amount;
+		public virtual decimal Amount
+		{
+			get => amount;
+			set => SetField(ref amount, value);
+		}
+
 		public int ExpectedAmount { get; set; }
 		public NomenclatureCategory Category { get; set; }
         public Direction? Direction { get; set; }


### PR DESCRIPTION
Убран вопрос "Сохранить изменения перед закрытием" при редактировании в диалогах при нажатии на кнопку "Отмена", когда пользователем не производились изменения.
Найдены все места в диалогах где в HasChanges выставляется True, либо с переопределённой логикой HasChanges и убраны, либо поправлены такие места.
Проверено, что связанные документы нормально сохраняются и что при выходе из диалога через кнопку отмена, диалоги не зависают.

Список найденных диалогов:

Убран HasChanges = true и проверена работа:
RouteListClosingDlg - Закрытие МЛ
RouteListMileageCheck - Проверка километража

HasChanges = true доработан:
SubDivisionDlg - Справочник подразделений
CarUnloadDocumentDlg - Талон разгрузки
SelfDeliveryDocumentDlg - Отпуск самовывоза

Найдены, но не требуют исправлений:
RouteListOnDayViewmodel, RoutesAtDayDlg - Формирование МЛ, нет кнопки отмена, не требует исправления
RouteListKeepingDlg - Диалог ведения, проблемы не наблюдается
TransferOperationDocumentDlg - Перенос между точками доставки, есть присвоения значений для HasChanges, но работает правильно
CarDlg - Справочник автомобилей, работает правильно
EmployeeDlg - Справочник сотрудников, работает правильно
TrainDlg - Справочник стажёров, работает правильно
FinancialDistrictsSetViewModel - Версии финансовых районов, работает правильно, не спрашивает
DistrictsSetViewModel - Журнал версий районов, работает правильно, не спрашивает