### PR TITLE
2995 - Доработки детализации зп в закрытии МЛ

### DIFF
--- a/Vodovoz/Dialogs/Logistic/RouteListClosingDlg.cs
+++ b/Vodovoz/Dialogs/Logistic/RouteListClosingDlg.cs
@@ -314,6 +314,8 @@ namespace Vodovoz
 				hbxStatistics1.Sensitive = false;
 				hbxStatistics2.Sensitive = false;
 				enummenuRLActions.Sensitive = false;
+				labelWage1.Visible = false;
+				toggleWageDetails.Sensitive = false;
 
 				HasChanges = false;
 
@@ -340,6 +342,8 @@ namespace Vodovoz
 			advanceCheckbox.Sensitive = advanceSpinbutton.Sensitive = editing;
 			spinCashOrder.Sensitive = buttonCreateCashOrder.Sensitive = editing;
 			buttonCalculateCash.Sensitive = editing;
+			labelWage1.Visible = editing;
+			toggleWageDetails.Sensitive = editing;
 			UpdateButtonState();
 		}
 

--- a/VodovozBusiness/Domain/Logistic/RouteListItemWageCalculationSource.cs
+++ b/VodovozBusiness/Domain/Logistic/RouteListItemWageCalculationSource.cs
@@ -134,6 +134,8 @@ namespace Vodovoz.Domain.Logistic
 
 		public (TimeSpan, TimeSpan) DeliverySchedule => (item.Order.DeliverySchedule.From, item.Order.DeliverySchedule.To);
 
+		public EmployeeCategory EmployeeCategory => employeeCategory;
+
 		#endregion IRouteListItemWageCalculationSource implementation
 	}
 }

--- a/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/DefaultRouteListWageCalculationService.cs
+++ b/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/DefaultRouteListWageCalculationService.cs
@@ -14,7 +14,8 @@ namespace Vodovoz.Domain.WageCalculation.CalculationServices.RouteList
 		{
 			RouteListItemWageCalculationDetails addressWageDetails = new RouteListItemWageCalculationDetails()
 			{
-				RouteListItemWageCalculationName = "Способ расчёта ЗП по умолчанию"
+				RouteListItemWageCalculationName = "Способ расчёта ЗП по умолчанию",
+				WageCalculationEmployeeCategory = source.EmployeeCategory
 			};
 
 			return addressWageDetails;

--- a/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/IRouteListItemWageCalculationSource.cs
+++ b/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/IRouteListItemWageCalculationSource.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Vodovoz.Domain.Employees;
 using Vodovoz.Domain.Sale;
 
 namespace Vodovoz.Domain.WageCalculation.CalculationServices.RouteList
@@ -110,5 +111,7 @@ namespace Vodovoz.Domain.WageCalculation.CalculationServices.RouteList
 		IEnumerable<IOrderDepositItemWageCalculationSource> OrderDepositItemsSource { get; }
 
 		bool IsDriverForeignDistrict { get; }
+
+		EmployeeCategory EmployeeCategory { get; }
 	}
 }

--- a/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/RouteListItemWageCalculationDetails.cs
+++ b/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/RouteListItemWageCalculationDetails.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
+using Vodovoz.Domain.Employees;
 
 namespace Vodovoz.Domain.WageCalculation.CalculationServices.RouteList
 {
 	public class RouteListItemWageCalculationDetails
 	{
 		public string RouteListItemWageCalculationName { get; set; }
+		public EmployeeCategory WageCalculationEmployeeCategory { get; set; }
 		public IList<WageCalculationDetailsItem> WageCalculationDetailsList { get; set; } = new List<WageCalculationDetailsItem>();
 	}
 

--- a/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/RouteListManualWageCalculationService.cs
+++ b/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/RouteListManualWageCalculationService.cs
@@ -27,7 +27,8 @@ namespace Vodovoz.Domain.WageCalculation.CalculationServices.RouteList
 		{
 			RouteListItemWageCalculationDetails addressWageDetails = new RouteListItemWageCalculationDetails()
 			{
-				RouteListItemWageCalculationName = wageParameterItem.Title
+				RouteListItemWageCalculationName = wageParameterItem.Title,
+				WageCalculationEmployeeCategory = source.EmployeeCategory
 			};
 
 			return addressWageDetails;

--- a/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/RouteListOldRatesWageCalculationService.cs
+++ b/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/RouteListOldRatesWageCalculationService.cs
@@ -159,7 +159,8 @@ namespace Vodovoz.Domain.WageCalculation.CalculationServices.RouteList
 		{
 			RouteListItemWageCalculationDetails addressWageDetails = new RouteListItemWageCalculationDetails()
 			{
-				RouteListItemWageCalculationName = wageParameterItem.Title
+				RouteListItemWageCalculationName = wageParameterItem.Title,
+				WageCalculationEmployeeCategory = source.EmployeeCategory
 			};
 
 			if(!src.IsDelivered)
@@ -189,19 +190,20 @@ namespace Vodovoz.Domain.WageCalculation.CalculationServices.RouteList
 					{
 						Name = $"Не первый заказ на точку доставки",
 					});
-				return addressWageDetails;
 			}
-
-			var rateAddress = GetActualRate(src.IsDriverForeignDistrict ? WageRateTypes.ForeignAddress : WageRateTypes.Address);
-			if(rateAddress != null)
+			else
 			{
-				addressWageDetails.WageCalculationDetailsList.Add(
-					new WageCalculationDetailsItem()
-					{
-						Name = $"{rateAddress.WageRateType.GetEnumTitle()}",
-						Count = 1,
-						Price = GetRateValue(src, rateAddress)
-					});
+				var rateAddress = GetActualRate(src.IsDriverForeignDistrict ? WageRateTypes.ForeignAddress : WageRateTypes.Address);
+				if(rateAddress != null)
+				{
+					addressWageDetails.WageCalculationDetailsList.Add(
+						new WageCalculationDetailsItem()
+						{
+							Name = $"{rateAddress.WageRateType.GetEnumTitle()}",
+							Count = 1,
+							Price = GetRateValue(src, rateAddress)
+						});
+				}
 			}
 
 			bool addressWithBigOrder = HasBigOrder(src);

--- a/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/RouteListPercentWageCalculationService.cs
+++ b/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/RouteListPercentWageCalculationService.cs
@@ -45,7 +45,8 @@ namespace Vodovoz.Domain.WageCalculation.CalculationServices.RouteList
 		{
 			RouteListItemWageCalculationDetails addressWageDetails = new RouteListItemWageCalculationDetails()
 			{
-				RouteListItemWageCalculationName = wageParameterItem.Title
+				RouteListItemWageCalculationName = wageParameterItem.Title,
+				WageCalculationEmployeeCategory = src.EmployeeCategory
 			};
 
 			switch(wageParameterItem.PercentWageType)

--- a/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/WageCalculationServiceForOldRouteLists.cs
+++ b/VodovozBusiness/Domain/WageCalculation/CalculationServices/RouteList/WageCalculationServiceForOldRouteLists.cs
@@ -29,7 +29,8 @@ namespace Vodovoz.Domain.WageCalculation.CalculationServices.RouteList
 		{
 			RouteListItemWageCalculationDetails addressWageDetails = new RouteListItemWageCalculationDetails()
 			{
-				RouteListItemWageCalculationName = "Расчёт ЗП для старых МЛ"
+				RouteListItemWageCalculationName = "Расчёт ЗП для старых МЛ",
+				WageCalculationEmployeeCategory = src.EmployeeCategory
 			};
 
 			addressWageDetails.WageCalculationDetailsList.Add(


### PR DESCRIPTION
1.  Добавлено право для просмотра вкладки детализация и информации о зп в футере диалога закрытия. Используется та же логика и то же право, по которой скрываются/отображаются колонки с зарплатой водителя и экспедитора. МЛ должен быть в статусах: Доставлен, Сдаётся, Проверка километража. У пользователя должно быть право: "Управление деньгами. Касса."
2. Все данные по водителю и экспедитору выводятся и считаются отдельно.
3. В детализацию добавлена новая проверка IsValidForWageCalculation из расчёта зп.