### PR TITLE
2342 Подгрузка актуальных оснований

### DIFF
--- a/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -564,7 +564,7 @@ namespace Vodovoz
 			depositrefunditemsview.Configure(UoWGeneric, Entity);
 			ycomboboxReason.SetRenderTextFunc<DiscountReason>(x => x.Name);
 			ycomboboxReason.ShowSpecialStateNot = true;
-			ycomboboxReason.PopupRequested += (o, args) => (o as ySpecComboBox).ItemsList = orderRepository.GetActiveDiscountReasons(UoW);
+			ycomboboxReason.ItemsList = orderRepository.GetActiveDiscountReasons(UoW);
 
 			yCmbReturnTareReasonCategories.SetRenderTextFunc<ReturnTareReasonCategory>(x => x.Name);
 			yCmbReturnTareReasonCategories.ItemsList = UoW.Session.QueryOver<ReturnTareReasonCategory>().List();

--- a/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -563,7 +563,8 @@ namespace Vodovoz
 			SetSensitivityOfPaymentType();
 			depositrefunditemsview.Configure(UoWGeneric, Entity);
 			ycomboboxReason.SetRenderTextFunc<DiscountReason>(x => x.Name);
-			ycomboboxReason.ItemsList = orderRepository.GetActiveDiscountReasons(UoW);
+			ycomboboxReason.ShowSpecialStateNot = true;
+			ycomboboxReason.PopupRequested += (o, args) => (o as ySpecComboBox).ItemsList = orderRepository.GetActiveDiscountReasons(UoW);
 
 			yCmbReturnTareReasonCategories.SetRenderTextFunc<ReturnTareReasonCategory>(x => x.Name);
 			yCmbReturnTareReasonCategories.ItemsList = UoW.Session.QueryOver<ReturnTareReasonCategory>().List();


### PR DESCRIPTION
Смотреть комменты к задаче
С одной стороны, при загрузке диалога заказа не будет каждый раз вызываться запрос на получение оснований
С другой стороны - пользователь может кликать туда сюда на вызов выпадающего списка и генерить лишние запросы ¯\_(ツ)_/¯
Плюс думал перед и после выполнения запроса менять Sensitivity, но работает как то криво
Ну а SpecialState считаю нужным добавить в любом случае. Сломать всякие if (Selected == null) не должно