### PR TITLE
3677 - Исправлены права для доступа в Планы продаж из меню Зарплата

### DIFF
--- a/Vodovoz/MainWindow.cs
+++ b/Vodovoz/MainWindow.cs
@@ -197,7 +197,12 @@ public partial class MainWindow : Gtk.Window
         ActionDriversWageBalance.Visible = hasAccessToSalaries;
         ActionCRM.Sensitive = hasAccessToCRM;
 
-        ActionWage.Sensitive = ServicesConfig.CommonServices.CurrentPermissionService.ValidatePresetPermission("can_edit_wage");
+        bool canEditWage = ServicesConfig.CommonServices.CurrentPermissionService.ValidatePresetPermission("can_edit_wage");
+        ActionWageDistrict.Sensitive = canEditWage;
+        ActionRates.Sensitive = canEditWage;
+
+        bool canEditWageBySelfSubdivision = ServicesConfig.CommonServices.CurrentPermissionService.ValidatePresetPermission("can_edit_wage_by_self_subdivision");
+        ActionSalesPlans.Sensitive = canEditWageBySelfSubdivision;
 
         ActionFinesJournal.Visible = ActionPremiumJournal.Visible = ServicesConfig.CommonServices.CurrentPermissionService.ValidatePresetPermission("access_to_fines_bonuses");
         ActionReports.Sensitive = false;


### PR DESCRIPTION
Всё меню Зарплата вместе с подменю засеривается при отсутствии права "Установка заработной платы". В подменю зарплаты есть пункт Планы продаж, который должен быть доступен пользователю с правом "Управление зп своего подразделения" (даже при отсутствии права "Установка заработной платы"). Проверка наличия данных прав перенесена с меню Зарплата на его подменю.