### PR TITLE
Фикс проверки добавленных листовок в заказе

### DIFF
--- a/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -1975,7 +1975,7 @@ namespace Vodovoz
 			}
 			else
 			{
-				if(_addedFlyersNomenclaturesIds.Any())
+				if(_addedFlyersNomenclaturesIds != null &&_addedFlyersNomenclaturesIds.Any())
 				{
 					foreach(var flyerNomenclatureId in _addedFlyersNomenclaturesIds)
 					{


### PR DESCRIPTION
При активации чекбокса "Самовывоз" точка доставки зануляется, а _addedFlyersNomenclaturesIds заполняется в методе TryAddFlyers только, если точка доставки не нулл. Поэтому _addedFlyersNomenclaturesIds был нуловым и проверка _addedFlyersNomenclaturesIds.Any() вызывала ошибку. Добавил проверку на null.
