### PR TITLE
3673 СМС при переносе заказа без аппрува

### DIFF
--- a/Vodovoz/Dialogs/UndeliveredOrderDlg.cs
+++ b/Vodovoz/Dialogs/UndeliveredOrderDlg.cs
@@ -141,7 +141,8 @@ namespace Vodovoz.Dialogs
 
 		protected void OnButtonSaveClicked(object sender, EventArgs e)
 		{
-			if(Save() && UndeliveredOrder.OrderTransferType == TransferType.AutoTransferNotApproved 
+			if(Save() && UndeliveredOrder.NewOrder != null
+			          && UndeliveredOrder.OrderTransferType == TransferType.AutoTransferNotApproved 
 			          && UndeliveredOrder.NewOrder.OrderStatus != OrderStatus.Canceled)
 			{
 				ProcessSmsNotification();

--- a/Vodovoz/Dialogs/UndeliveredOrderDlg.cs
+++ b/Vodovoz/Dialogs/UndeliveredOrderDlg.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using FluentNHibernate.Data;
 using Gtk;
 using QS.Dialog.GtkUI;
 using QS.DomainModel.UoW;
@@ -8,6 +9,7 @@ using QS.Tdi;
 using QS.Validation;
 using Vodovoz.Core.DataService;
 using Vodovoz.Domain.Orders;
+using Vodovoz.Domain.Sms;
 using Vodovoz.EntityRepositories.CallTasks;
 using Vodovoz.EntityRepositories.Employees;
 using Vodovoz.EntityRepositories.Orders;
@@ -139,8 +141,18 @@ namespace Vodovoz.Dialogs
 
 		protected void OnButtonSaveClicked(object sender, EventArgs e)
 		{
-			Save();
+			if(Save() && UndeliveredOrder.OrderTransferType == TransferType.AutoTransferNotApproved 
+			          && UndeliveredOrder.NewOrder.OrderStatus != OrderStatus.Canceled)
+			{
+				ProcessSmsNotification();
+			}
 			DlgSaved?.Invoke(this, new UndeliveryOnOrderCloseEventArgs(UndeliveredOrder));
+		}
+	
+		private void ProcessSmsNotification()
+		{
+			SmsNotifier smsNotifier = new SmsNotifier(new BaseParametersProvider());
+			smsNotifier.NotifyUndeliveryAutoTransferNotApproved(UndeliveredOrder);
 		}
 
 		protected void OnButtonCancelClicked(object sender, EventArgs e)

--- a/VodovozBusiness/Domain/Service/BaseParametersServices/BaseParametersProvider.cs
+++ b/VodovozBusiness/Domain/Service/BaseParametersServices/BaseParametersProvider.cs
@@ -184,6 +184,14 @@ namespace Vodovoz.Core.DataService
 			}
 			return SingletonParametersProvider.Instance.GetParameterValue("low_balance_sms_notify_text");
 		}
+		
+		public string GetUndeliveryAutoTransferNotApprovedTextTemplate()
+		{
+			if(!SingletonParametersProvider.Instance.ContainsParameter("undelivery_autotransport_notapproved_sms_text_template")) {
+				throw new InvalidProgramException("В параметрах базы не настроен шаблон для смс уведомлений о переносе при недовозе  без согласования(undelivery_autotransport_notapproved_sms_text_template).");
+			}
+			return SingletonParametersProvider.Instance.GetParameterValue("undelivery_autotransport_notapproved_sms_text_template");
+		}
 
 		#endregion ISmsNotifierParameters implementation
 

--- a/VodovozBusiness/Domain/Service/BaseParametersServices/BaseParametersProvider.cs
+++ b/VodovozBusiness/Domain/Service/BaseParametersServices/BaseParametersProvider.cs
@@ -187,7 +187,8 @@ namespace Vodovoz.Core.DataService
 		
 		public string GetUndeliveryAutoTransferNotApprovedTextTemplate()
 		{
-			if(!SingletonParametersProvider.Instance.ContainsParameter("undelivery_autotransport_notapproved_sms_text_template")) {
+			if(!SingletonParametersProvider.Instance.ContainsParameter("undelivery_autotransport_notapproved_sms_text_template")) 
+			{
 				throw new InvalidProgramException("В параметрах базы не настроен шаблон для смс уведомлений о переносе при недовозе  без согласования(undelivery_autotransport_notapproved_sms_text_template).");
 			}
 			return SingletonParametersProvider.Instance.GetParameterValue("undelivery_autotransport_notapproved_sms_text_template");

--- a/VodovozBusiness/Domain/Sms/SmsNotificationType.cs
+++ b/VodovozBusiness/Domain/Sms/SmsNotificationType.cs
@@ -7,6 +7,8 @@ namespace Vodovoz.Domain.Sms
 		[Display(Name = "При новом контрагенте")]
 		NewClient,
 		[Display(Name = "При низком балансе")]
-		LowBalance
+		LowBalance,
+		[Display(Name = "При недовозе в переносе 'автоперенос н/согл' ")]
+		UndeliveryNotApproved
 	}
 }

--- a/VodovozBusiness/Domain/Sms/SmsNotifier.cs
+++ b/VodovozBusiness/Domain/Sms/SmsNotifier.cs
@@ -83,12 +83,113 @@ namespace Vodovoz.Domain.Sms
 				uow.Save();
 			}
 		}
+		
+		/// <summary>
+		/// Создает новое смс-уведомление для недовоза, если до клиента не дозвонились.
+		/// Все равно происходит перенос заказа на следующий день.
+		/// </summary>
+		/// <param name="undeliveredOrder"></param>
+		public void NotifyUndeliveryAutoTransferNotApproved(UndeliveredOrder undeliveredOrder)
+		{
+			if(!smsNotifierParametersProvider.IsSmsNotificationsEnabled) {
+				return;
+			}
+
+			//необходимые проверки именно НОВОГО заказа
+			if(undeliveredOrder.NewOrder == null || undeliveredOrder.NewOrder.Id == 0 || undeliveredOrder.NewOrder.OrderStatus == OrderStatus.NewOrder || !undeliveredOrder.NewOrder.DeliveryDate.HasValue) {
+				return;
+			}
+			if(undeliveredOrder.NewOrder.Client.FirstOrder == null 
+			   || undeliveredOrder.OrderTransferType != TransferType.AutoTransferNotApproved) {
+				return;
+			}
+			
+			//проверка уже существующих ранее уведомлений по недовозу
+			using(var uow = UnitOfWorkFactory.CreateWithoutRoot()) {
+				var existsNotifications = uow.Session.QueryOver<UndeliveryNotApprovedSmsNotification>()
+					.Where(x => x.UndeliveredOrder.Id == undeliveredOrder.Id) //
+					.List();
+				if(existsNotifications.Any()) {
+					return;
+				}
+			}
+			
+			//формирование номера мобильного телефона
+			string mobilePhoneNumber = GetMobilePhoneNumberForUndeliveryOrderId(undeliveredOrder.Id);
+			if(string.IsNullOrWhiteSpace(mobilePhoneNumber)) {
+				return;
+			}
+			
+			//получение текста сообщения
+			var msgToSend = smsNotifierParametersProvider.GetUndeliveryAutoTransferNotApprovedTextTemplate();
+
+			//формирование текста сообщения
+			//метки для замены в тексте сообщения из базы
+			const string deliveryDateVariable = "$delivery_date$";
+			const string deliveryTimeVariable = "$delivery_time$";
+			//формирование времени доставки и проверка на Null exception
+			string orderScheduleTimeString = undeliveredOrder.NewOrder.DeliverySchedule 
+			                                 != null ? $"c {undeliveredOrder.NewOrder.DeliverySchedule.From.Hours}" +
+			                                           $":{undeliveredOrder.NewOrder.DeliverySchedule.From.Minutes:D2} " +
+			                                           $"по {undeliveredOrder.NewOrder.DeliverySchedule.To.Hours}" +
+			                                           $":{undeliveredOrder.NewOrder.DeliverySchedule.To.Minutes:D2}" : "";
+			if(string.IsNullOrWhiteSpace(orderScheduleTimeString))
+			{
+				return;
+			}
+			//замена метки на дату доставки
+			msgToSend = msgToSend.Replace(deliveryDateVariable, $"{undeliveredOrder.NewOrder.DeliveryDate.Value.ToString("dd.MM.yyyy")}");
+			//замена метки на время доставки
+			msgToSend = msgToSend.Replace(deliveryTimeVariable, $"{orderScheduleTimeString}");
+
+			//создание нового уведомления для отправки
+			using(var uow = UnitOfWorkFactory.CreateWithNewRoot<UndeliveryNotApprovedSmsNotification>()) {
+				//uow.Root.UndeliveredOrder.NewOrder = undeliveredOrder.NewOrder;
+				uow.Root.UndeliveredOrder = undeliveredOrder;
+				uow.Root.Counterparty = undeliveredOrder.NewOrder.Client;
+				uow.Root.NotifyTime = DateTime.Now;
+				uow.Root.MobilePhone = mobilePhoneNumber;
+				uow.Root.Status = SmsNotificationStatus.New;
+				uow.Root.MessageText = msgToSend;
+				uow.Root.ExpiredTime = new DateTime(
+					undeliveredOrder.OldOrder.DeliveryDate.Value.Year,
+					undeliveredOrder.OldOrder.DeliveryDate.Value.Month,
+					undeliveredOrder.OldOrder.DeliveryDate.Value.Day,
+					23, 59, 59
+				);
+
+				uow.Save();
+			}
+
+		}
 
 		private string GetMobilePhoneNumberForOrder(Order order)
 		{
 			Phone phone = null;
 			if(order.DeliveryPoint != null && !order.DeliveryPoint.Phones.Any()) {
 				phone = order.DeliveryPoint.Phones.FirstOrDefault();
+			} else {
+				phone = order.Client.Phones.FirstOrDefault();
+			}
+			if(phone == null) {
+				return null;
+			}
+
+			string stringPhoneNumber = phone.DigitsNumber.TrimStart('+').TrimStart('7').TrimStart('8');
+			if(stringPhoneNumber.Length == 0 || stringPhoneNumber.First() != '9' || stringPhoneNumber.Length != 10) {
+				return null;
+			}
+			return $"+7{stringPhoneNumber}";
+		}
+		
+		private string GetMobilePhoneNumberForUndeliveryOrderId(int id)
+		{
+			var UoW = UnitOfWorkFactory.CreateForRoot<UndeliveredOrder>(id);
+			var orderUnd = UoW.RootObject as UndeliveredOrder;
+			var order = orderUnd.OldOrder;
+			Phone phone = null;
+			if(order.DeliveryPoint != null && order.DeliveryPoint.Phones.Count>0) {
+				phone = order.DeliveryPoint.Phones.FirstOrDefault(); 
 			} else {
 				phone = order.Client.Phones.FirstOrDefault();
 			}

--- a/VodovozBusiness/Domain/Sms/SmsNotifier.cs
+++ b/VodovozBusiness/Domain/Sms/SmsNotifier.cs
@@ -208,12 +208,6 @@ namespace Vodovoz.Domain.Sms
 				return null;
 			}
 
-			//прямой мобильный городской номер
-			if(phone.DigitsNumber.Length == 7)
-			{
-				return phone.DigitsNumber;
-			}
-
 			//федеральный мобильный номер
 			string stringPhoneNumber = phone.DigitsNumber.TrimStart('+').TrimStart('7').TrimStart('8');
 			if(stringPhoneNumber.Length == 0 || stringPhoneNumber.First() != '9' || stringPhoneNumber.Length != 10) 

--- a/VodovozBusiness/Domain/Sms/SmsNotifier.cs
+++ b/VodovozBusiness/Domain/Sms/SmsNotifier.cs
@@ -198,7 +198,8 @@ namespace Vodovoz.Domain.Sms
 			if(order.DeliveryPoint != null && order.DeliveryPoint.Phones.Count > 0) 
 			{
 				phone = order.DeliveryPoint.Phones.FirstOrDefault(); 
-			} else 
+			} 
+			else 
 			{
 				phone = order.Client.Phones.FirstOrDefault();
 			}
@@ -207,6 +208,13 @@ namespace Vodovoz.Domain.Sms
 				return null;
 			}
 
+			//прямой мобильный городской номер
+			if(phone.DigitsNumber.Length == 7)
+			{
+				return phone.DigitsNumber;
+			}
+
+			//федеральный мобильный номер
 			string stringPhoneNumber = phone.DigitsNumber.TrimStart('+').TrimStart('7').TrimStart('8');
 			if(stringPhoneNumber.Length == 0 || stringPhoneNumber.First() != '9' || stringPhoneNumber.Length != 10) 
 			{

--- a/VodovozBusiness/Domain/Sms/SmsNotifier.cs
+++ b/VodovozBusiness/Domain/Sms/SmsNotifier.cs
@@ -192,8 +192,8 @@ namespace Vodovoz.Domain.Sms
 		
 		private string GetMobilePhoneNumberForUndeliveryOrderId(int id)
 		{
-			var UoW = UnitOfWorkFactory.CreateForRoot<UndeliveredOrder>(id);
-			var order = UoW.Root.OldOrder;
+			var uow = UnitOfWorkFactory.CreateForRoot<UndeliveredOrder>(id);
+			var order = uow.Root.OldOrder;
 			Phone phone = null;
 			if(order.DeliveryPoint != null && order.DeliveryPoint.Phones.Count > 0) 
 			{

--- a/VodovozBusiness/Domain/Sms/UndeliveryNotApprovedSmsNotification.cs
+++ b/VodovozBusiness/Domain/Sms/UndeliveryNotApprovedSmsNotification.cs
@@ -15,6 +15,7 @@ namespace Vodovoz.Domain.Sms
 	public class UndeliveryNotApprovedSmsNotification : SmsNotification
 	{
 		private UndeliveredOrder _undeliveredOrder;
+		private Counterparty _counterparty;
 		
 		public override SmsNotificationType SmsNotificationType => SmsNotificationType.UndeliveryNotApproved;
 		
@@ -24,13 +25,12 @@ namespace Vodovoz.Domain.Sms
 			get => _undeliveredOrder;
 			set => SetField(ref _undeliveredOrder, value);
 		}
-
-		private Counterparty counterparty;
+		
 		[Display(Name = "Контрагент")]
 		public virtual Counterparty Counterparty 
 		{
-			get => counterparty;
-			set => SetField(ref counterparty, value);
+			get => _counterparty;
+			set => SetField(ref _counterparty, value);
 		}
 	}
 }

--- a/VodovozBusiness/Domain/Sms/UndeliveryNotApprovedSmsNotification.cs
+++ b/VodovozBusiness/Domain/Sms/UndeliveryNotApprovedSmsNotification.cs
@@ -14,20 +14,23 @@ namespace Vodovoz.Domain.Sms
 	[HistoryTrace]
 	public class UndeliveryNotApprovedSmsNotification : SmsNotification
 	{
+		private UndeliveredOrder _undeliveredOrder;
+		
 		public override SmsNotificationType SmsNotificationType => SmsNotificationType.UndeliveryNotApproved;
-
-		private UndeliveredOrder undeliveredOrder;
+		
 		[Display(Name = "Недовоз")]
-		public virtual UndeliveredOrder UndeliveredOrder {
-			get => undeliveredOrder;
-			set => SetField(ref undeliveredOrder, value, () => UndeliveredOrder);
+		public virtual UndeliveredOrder UndeliveredOrder 
+		{
+			get => _undeliveredOrder;
+			set => SetField(ref _undeliveredOrder, value);
 		}
 
 		private Counterparty counterparty;
 		[Display(Name = "Контрагент")]
-		public virtual Counterparty Counterparty {
+		public virtual Counterparty Counterparty 
+		{
 			get => counterparty;
-			set => SetField(ref counterparty, value, () => Counterparty);
+			set => SetField(ref counterparty, value);
 		}
 	}
 }

--- a/VodovozBusiness/Domain/Sms/UndeliveryNotApprovedSmsNotification.cs
+++ b/VodovozBusiness/Domain/Sms/UndeliveryNotApprovedSmsNotification.cs
@@ -1,0 +1,34 @@
+﻿using System.ComponentModel.DataAnnotations;
+using QS.DomainModel.Entity;
+using QS.DomainModel.Entity.EntityPermissions;
+using QS.HistoryLog;
+using Vodovoz.Domain.Client;
+using Vodovoz.Domain.Orders;
+
+namespace Vodovoz.Domain.Sms
+{
+	//FEDOS
+	[Appellative(Gender = GrammaticalGender.Masculine,
+		NominativePlural = "смс уведомления при н/согл автопереносе в недовозе при переносе",
+		Nominative = "смс уведомление при н/согл автопереносе в недовозе при переносе")]
+	[EntityPermission]
+	[HistoryTrace]
+	public class UndeliveryNotApprovedSmsNotification : SmsNotification
+	{
+		public override SmsNotificationType SmsNotificationType => SmsNotificationType.UndeliveryNotApproved;
+
+		private UndeliveredOrder undeliveredOrder;
+		[Display(Name = "Недовоз")]
+		public virtual UndeliveredOrder UndeliveredOrder {
+			get => undeliveredOrder;
+			set => SetField(ref undeliveredOrder, value, () => UndeliveredOrder);
+		}
+
+		private Counterparty counterparty;
+		[Display(Name = "Контрагент")]
+		public virtual Counterparty Counterparty {
+			get => counterparty;
+			set => SetField(ref counterparty, value, () => Counterparty);
+		}
+	}
+}

--- a/VodovozBusiness/Domain/Sms/UndeliveryNotApprovedSmsNotification.cs
+++ b/VodovozBusiness/Domain/Sms/UndeliveryNotApprovedSmsNotification.cs
@@ -7,7 +7,6 @@ using Vodovoz.Domain.Orders;
 
 namespace Vodovoz.Domain.Sms
 {
-	//FEDOS
 	[Appellative(Gender = GrammaticalGender.Masculine,
 		NominativePlural = "смс уведомления при н/согл автопереносе в недовозе при переносе",
 		Nominative = "смс уведомление при н/согл автопереносе в недовозе при переносе")]

--- a/VodovozBusiness/HibernateMapping/Sms/SmsNotificationMap.cs
+++ b/VodovozBusiness/HibernateMapping/Sms/SmsNotificationMap.cs
@@ -41,4 +41,14 @@ namespace Vodovoz.HibernateMapping.Sms
 			Map(x => x.Balance).Column ("balance");
 		}
 	}
+	
+	public class UndeliveryNotApprovedSmsNotificationMap : SubclassMap<UndeliveryNotApprovedSmsNotification>
+	{
+		public UndeliveryNotApprovedSmsNotificationMap()
+		{
+			DiscriminatorValue(nameof(SmsNotificationType.UndeliveryNotApproved));
+			References(x => x.UndeliveredOrder).Column("undeliveried_order_id");
+			References(x => x.Counterparty).Column("counterparty_id");
+		}
+	}
 }

--- a/VodovozBusiness/Services/ISmsNotifierParametersProvider.cs
+++ b/VodovozBusiness/Services/ISmsNotifierParametersProvider.cs
@@ -7,5 +7,6 @@
 		decimal GetLowBalanceLevel();
 		string GetLowBalanceNotifiedPhone();
 		string GetLowBalanceNotifyText();
+		string GetUndeliveryAutoTransferNotApprovedTextTemplate();
 	}
 }

--- a/VodovozBusiness/VodovozBusiness.csproj
+++ b/VodovozBusiness/VodovozBusiness.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Domain\Sale\WeekDayDistrictRuleItem.cs" />
     <Compile Include="Domain\Security\RegisteredRM.cs" />
     <Compile Include="Domain\SmsPayment.cs" />
+    <Compile Include="Domain\Sms\UndeliveryNotApprovedSmsNotification.cs" />
     <Compile Include="Domain\WageCalculation\CalculationServices\RouteList\RouteListItemWageCalculationDetails.cs" />
     <Compile Include="Domain\WageCalculation\CalculationServices\RouteList\RouteListWageCalculationService.cs" />
     <Compile Include="Domain\WageCalculation\EmployeeWageParameter.cs" />


### PR DESCRIPTION
Необходимые изменения БД в комментарии к задаче.

Функционал формирования смс для клиента, если в недовозе при переносе заказа клиент не ответил на звонок и не подтвердил перенос. Заказ всё равно переносят и присылают смс-уведомление.

Добавлен новый класс смс-уведомлений с Counterparty и UndeliveredOrder.

 Добавлен новый геттер шаблона сообщения из параметров базы.
 
 Добавлен новый тип уведомлений - UndeliveryNotApproved.
 
 Новый метод формирования смс-уведомления в SmsNotifier. В методе присутствуют все необходимые проверки и занесение уведомления в базу со статусом "New".
 
 Метод вызывается при соблюдении необходимых условий при сохранении недовоза.

Добавлен новый формирователь номера телефона для недовоза.