### PR TITLE
3673 Добавление смс-сервиса по недовозам

### DIFF
--- a/Services/Application/VodovozSmsInformerService/Program.cs
+++ b/Services/Application/VodovozSmsInformerService/Program.cs
@@ -18,7 +18,7 @@ namespace VodovozSmsInformerService
     class Service
 	{
 		private static Logger logger = LogManager.GetCurrentClassLogger();
-
+		
 		private static readonly string configFile = "/etc/vodovoz-smsinformer-service.conf";
 
 		//Service
@@ -33,6 +33,7 @@ namespace VodovozSmsInformerService
 		private static string mysqlDatabase;
 
 		static NewClientSmsInformer newClientInformer;
+		static UndeliveryNotApprovedSmsInformer undeliveryNotApprovedSmsInformer;
 
 		public static void Main(string[] args)
 		{
@@ -109,13 +110,16 @@ namespace VodovozSmsInformerService
 				ISmsNotificationRepository smsNotificationRepository = new SmsNotificationRepository();
 
 				SmsRuSendController smsSender = new SmsRuSendController(smsRuConfig);
-
+				
 				newClientInformer = new NewClientSmsInformer(smsSender, smsNotificationRepository);
 				newClientInformer.Start();
 
 				BaseParametersProvider parametersProvider = new BaseParametersProvider();
 				LowBalanceNotifier lowBalanceNotifier = new LowBalanceNotifier(smsSender, smsSender, parametersProvider);
 				lowBalanceNotifier.Start();
+				
+				undeliveryNotApprovedSmsInformer = new UndeliveryNotApprovedSmsInformer(smsSender, smsNotificationRepository);
+				undeliveryNotApprovedSmsInformer.Start();
 
 				SmsInformerInstanceProvider serviceStatusInstanceProvider = new SmsInformerInstanceProvider(
 					smsNotificationRepository, 
@@ -154,6 +158,7 @@ namespace VodovozSmsInformerService
 		static void CurrentDomain_ProcessExit(object sender, EventArgs e)
 		{
 			newClientInformer?.Stop();
+			undeliveryNotApprovedSmsInformer.Stop();
 		}
 	}
 }

--- a/Services/Application/VodovozSmsInformerService/UndeliveryNotApprovedSmsInformer.cs
+++ b/Services/Application/VodovozSmsInformerService/UndeliveryNotApprovedSmsInformer.cs
@@ -1,0 +1,7 @@
+﻿namespace VodovozSmsInformerService
+{
+	public class UndeliveryNotApprovedSmsInformer
+	{
+		
+	}
+}

--- a/Services/Application/VodovozSmsInformerService/UndeliveryNotApprovedSmsInformer.cs
+++ b/Services/Application/VodovozSmsInformerService/UndeliveryNotApprovedSmsInformer.cs
@@ -1,7 +1,135 @@
-﻿namespace VodovozSmsInformerService
+﻿using System;
+using SmsSendInterface;
+using QS.DomainModel.UoW;
+using Vodovoz.Domain.Sms;
+using System.Collections.Generic;
+using System.Linq;
+using System.Timers;
+using NLog;
+using Vodovoz.EntityRepositories.SmsNotifications;
+using SmsRuSendService;
+
+namespace VodovozSmsInformerService
 {
+	/// <summary>
+	/// Отправляет смс уведомление при переносе недовоза, если клиенту не дозвонились
+	/// </summary>
 	public class UndeliveryNotApprovedSmsInformer
 	{
+		private static Logger logger = LogManager.GetCurrentClassLogger();
+
+		private readonly ISmsSender smsSender;
+		private readonly ISmsNotificationRepository smsNotificationRepository;
+		private Timer timer;
+		private bool sendingInProgress = false;
+		private const int refreshInterval = 60000;
+
+		public UndeliveryNotApprovedSmsInformer(ISmsSender smsSender, ISmsNotificationRepository smsNotificationRepository)
+		{
+			this.smsSender = smsSender ?? throw new ArgumentNullException(nameof(smsSender));
+			this.smsNotificationRepository = smsNotificationRepository ?? throw new ArgumentNullException(nameof(smsNotificationRepository));
+		}
+
+		public void Start()
+		{
+			timer = new Timer(refreshInterval);
+			timer.Elapsed += Timer_Elapsed;
+			timer.Start();
+			logger.Info($"Запущена отправка смс уведомлений о переносе недовоза. Проверка новых уведомлений каждые {refreshInterval/1000} сек.");
+		}
+
+		public void Stop()
+		{
+			timer?.Stop();
+			timer?.Dispose();
+			timer = null;
+			logger.Info($"Остановлена отправка смс уведомлений о переносе недовоза.");
+		}
+
+		private void Timer_Elapsed(object sender, ElapsedEventArgs e)
+		{
+			SendNewNotifications();
+		}
 		
+		private void CloseExpiredNotifications(IUnitOfWork uow, IEnumerable<UndeliveryNotApprovedSmsNotification> notifications)
+		{
+			var expiredNotifications = notifications.Where(x => x.Status == SmsNotificationStatus.New)
+				//проверка даты УЧИТЫВАЯ время
+				.Where(x => x.ExpiredTime < DateTime.Now);
+			if(expiredNotifications.Any()) {
+				logger.Info($"Были закрыты без отправки следующие просроченные уведомления: {string.Join(", ", expiredNotifications.Select(x => x.Id))}");
+			}
+			foreach(var expiredNotification in expiredNotifications) {
+				expiredNotification.Status = SmsNotificationStatus.SendExpired;
+				uow.Save(expiredNotification);
+			}
+		}
+
+		private void SendNewNotifications()
+		{
+			logger.Debug($"Новый вызов отправки смс уведомлений о переносе недовоза");
+			if(sendingInProgress) {
+				logger.Debug($"Вывоз новой отправки о недовозе до завершения предыдущей!");
+				return;
+			}
+			sendingInProgress = true;
+			try {
+				using(var uow = UnitOfWorkFactory.CreateWithoutRoot()) {
+					var newNotifications = smsNotificationRepository.GetUnsendedUndeliveryNotApprovedSmsNotifications(uow);
+					if(!newNotifications.Any()) {
+						return;
+					}
+					//закрытие просроченных уведомлений
+					CloseExpiredNotifications(uow, newNotifications);
+					//повторное получение уведомлений после закрытия истёкших
+					newNotifications = newNotifications.Where(x => x.Status == SmsNotificationStatus.New).ToList();
+
+					foreach(var notification in newNotifications) {
+						SendNotification(notification);
+						uow.Save(notification);
+					}
+					uow.Commit();
+				}
+			}
+			catch(Exception ex) {
+				logger.Fatal(ex);
+			}
+			finally {
+				sendingInProgress = false;
+			}
+		}
+
+		private void SendNotification(UndeliveryNotApprovedSmsNotification notification)
+		{
+			try {
+				SmsMessage smsMessage = new SmsMessage(notification.MobilePhone, notification.Id.ToString(), notification.MessageText);
+				var result = smsSender.SendSms(smsMessage);
+				logger.Info($"Отправлено уведомление о переносе недовоза. Тел.: {smsMessage.MobilePhoneNumber}, результат: {result.Status}");
+
+				notification.ServerMessageId = result.ServerId;
+				notification.Status = result.Status == SmsSentStatus.Accepted ? SmsNotificationStatus.Accepted : SmsNotificationStatus.Error;
+				switch(result.Status) {
+					case SmsSentStatus.InvalidMobilePhone:
+						notification.ErrorDescription = $"Неверно заполнен номер мобильного телефона. ({notification.MobilePhone})";
+						break;
+					case SmsSentStatus.TextIsEmpty:
+						notification.ErrorDescription = $"Не заполнен текст сообщения";
+						break;
+					case SmsSentStatus.SenderAddressInvalid:
+						notification.ErrorDescription = $"Неверное имя отправителя";
+						break;
+					case SmsSentStatus.NotEnoughBalance:
+						notification.ErrorDescription = $"Недостаточно средств на счете";
+						break;
+					case SmsSentStatus.UnknownError:
+						notification.ErrorDescription = $"{result.Description}";
+						break;
+				}
+			}
+			catch(Exception ex) {
+				notification.ErrorDescription = $"Ошибка при отправке смс сообщения. {ex.Message}";
+				logger.Error(ex);
+			}
+		}
 	}
 }

--- a/Services/Application/VodovozSmsInformerService/VodovozSmsInformerService.csproj
+++ b/Services/Application/VodovozSmsInformerService/VodovozSmsInformerService.csproj
@@ -64,6 +64,7 @@
     <Compile Include="SmsInformerInstanceProvider.cs" />
     <Compile Include="SmsInformerServiceHost.cs" />
     <Compile Include="SmsInformerServiceBehavior.cs" />
+    <Compile Include="UndeliveryNotApprovedSmsInformer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/VodovozBusiness/Domain/Sms/SmsNotifier.cs
+++ b/VodovozBusiness/Domain/Sms/SmsNotifier.cs
@@ -160,12 +160,12 @@ namespace Vodovoz.Domain.Sms
 				uow.Root.Status = SmsNotificationStatus.New;
 				uow.Root.MessageText = msgToSend;
 				uow.Root.ExpiredTime = new DateTime(
-					undeliveredOrder.NewOrder.DeliveryDate.Value.Year,
-					undeliveredOrder.NewOrder.DeliveryDate.Value.Month,
-					undeliveredOrder.NewOrder.DeliveryDate.Value.Day,
-					undeliveredOrder.NewOrder.DeliveryDate.Value.Hour, 
-					undeliveredOrder.NewOrder.DeliveryDate.Value.Minute, 
-					undeliveredOrder.NewOrder.DeliveryDate.Value.Second
+					DateTime.Now.Year,
+					DateTime.Now.Month,
+					DateTime.Now.Day,
+					DateTime.Now.Hour, 
+					DateTime.Now.Minute+30, 
+					DateTime.Now.Second
 				);
 
 				uow.Save();

--- a/VodovozBusiness/Domain/Sms/SmsNotifier.cs
+++ b/VodovozBusiness/Domain/Sms/SmsNotifier.cs
@@ -160,10 +160,12 @@ namespace Vodovoz.Domain.Sms
 				uow.Root.Status = SmsNotificationStatus.New;
 				uow.Root.MessageText = msgToSend;
 				uow.Root.ExpiredTime = new DateTime(
-					undeliveredOrder.OldOrder.DeliveryDate.Value.Year,
-					undeliveredOrder.OldOrder.DeliveryDate.Value.Month,
-					undeliveredOrder.OldOrder.DeliveryDate.Value.Day,
-					23, 59, 59
+					undeliveredOrder.NewOrder.DeliveryDate.Value.Year,
+					undeliveredOrder.NewOrder.DeliveryDate.Value.Month,
+					undeliveredOrder.NewOrder.DeliveryDate.Value.Day,
+					undeliveredOrder.NewOrder.DeliveryDate.Value.Hour, 
+					undeliveredOrder.NewOrder.DeliveryDate.Value.Minute, 
+					undeliveredOrder.NewOrder.DeliveryDate.Value.Second
 				);
 
 				uow.Save();

--- a/VodovozBusiness/Domain/Sms/SmsNotifier.cs
+++ b/VodovozBusiness/Domain/Sms/SmsNotifier.cs
@@ -159,15 +159,8 @@ namespace Vodovoz.Domain.Sms
 				uow.Root.MobilePhone = mobilePhoneNumber;
 				uow.Root.Status = SmsNotificationStatus.New;
 				uow.Root.MessageText = msgToSend;
-				uow.Root.ExpiredTime = new DateTime(
-					DateTime.Now.Year,
-					DateTime.Now.Month,
-					DateTime.Now.Day,
-					DateTime.Now.Hour, 
-					DateTime.Now.Minute+30, 
-					DateTime.Now.Second
-				);
-
+				uow.Root.ExpiredTime = DateTime.Now.AddMinutes(30);
+				
 				uow.Save();
 			}
 

--- a/VodovozBusiness/EntityRepositories/SmsNotifications/ISmsNotificationRepository.cs
+++ b/VodovozBusiness/EntityRepositories/SmsNotifications/ISmsNotificationRepository.cs
@@ -7,5 +7,6 @@ namespace Vodovoz.EntityRepositories.SmsNotifications
 	public interface ISmsNotificationRepository
 	{
 		IEnumerable<NewClientSmsNotification> GetUnsendedNewClientSmsNotifications(IUnitOfWork uow);
+		IEnumerable<UndeliveryNotApprovedSmsNotification> GetUnsendedUndeliveryNotApprovedSmsNotifications(IUnitOfWork uow);
 	}
 }

--- a/VodovozBusiness/EntityRepositories/SmsNotifications/SmsNotificationRepository.cs
+++ b/VodovozBusiness/EntityRepositories/SmsNotifications/SmsNotificationRepository.cs
@@ -12,5 +12,12 @@ namespace Vodovoz.EntityRepositories.SmsNotifications
 						.Where(x => x.Status == SmsNotificationStatus.New)
 						.List();
 		}
+
+		public IEnumerable<UndeliveryNotApprovedSmsNotification> GetUnsendedUndeliveryNotApprovedSmsNotifications(IUnitOfWork uow)
+		{
+			return uow.Session.QueryOver<UndeliveryNotApprovedSmsNotification>()
+				.Where(x => x.Status == SmsNotificationStatus.New)
+				.List();
+		}
 	}
 }


### PR DESCRIPTION
Сервис уведомлений о недовозе, сделанный по аналогии с сервисом уведомлений новых клиентов.
Получает уведомления со статусом "New" и типом "UndeliveryNotApprover", удаляет истёкшие уведомления (если такие каким-то образом появились) и отправляет новые, переводя статус в "Отправлено"