### PR TITLE
3366 Изменение даты контракта в первом заказе клиента, если заказ уже в базе

### DIFF
--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -215,7 +215,7 @@ namespace Vodovoz.Domain.Orders
 				if(Contract != null && Contract.Id != 0 && DeliveryDate.HasValue 
 				   && lastDate==Contract.IssueDate 
 				   && Contract.IssueDate != DeliveryDate.Value
-				   && _orderRepository.IfOrderDeliveryIsFirst(UoW, Client, value.Value, Id)
+				   && _orderRepository.IfOrderDeliveryIsFirst(UoW, Client, Id)
 				   && OrderStatus != OrderStatus.Closed)
 				{
 					Contract.IssueDate = DeliveryDate.Value.Date;

--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -206,10 +206,21 @@ namespace Vodovoz.Domain.Orders
 			get => deliveryDate;
 			set
 			{
+				var lastDate = deliveryDate;
 				if(SetField(ref deliveryDate, value) && 
 				   Contract != null && Contract.Id == 0)
 				{
 					UpdateContract();
+				}
+				if(Contract != null && Contract.Id != 0 && DeliveryDate.HasValue 
+				   && lastDate==Contract.IssueDate 
+				   && Contract.IssueDate != DeliveryDate.Value
+				   && _orderRepository.IfOrderDeliveryIsFirst(UoW, Client, value.Value, Id)
+				   && OrderStatus != OrderStatus.Closed)
+				{
+					Contract.IssueDate = DeliveryDate.Value.Date;
+					InteractiveService.ShowMessage(ImportanceLevel.Warning,
+						"Дата договора будет изменена при сохранении текущего заказа!");
 				}
 			}
 		}

--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -213,9 +213,9 @@ namespace Vodovoz.Domain.Orders
 					UpdateContract();
 				}
 				if(Contract != null && Contract.Id != 0 && DeliveryDate.HasValue 
-				   && lastDate==Contract.IssueDate 
+				   && lastDate == Contract.IssueDate 
 				   && Contract.IssueDate != DeliveryDate.Value
-				   && _orderRepository.IfOrderDeliveryIsFirst(UoW, Client, Id)
+				   && _orderRepository.CanChangeContractDate(UoW, Client, DeliveryDate.Value, Id)
 				   && OrderStatus != OrderStatus.Closed)
 				{
 					Contract.IssueDate = DeliveryDate.Value.Date;

--- a/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
@@ -93,7 +93,7 @@ namespace Vodovoz.EntityRepositories.Orders
 		/// <param name="client"></param>
 		/// <param name="newDeliveryDate"></param>
 		/// <returns></returns>
-		bool IfOrderDeliveryIsFirst(IUnitOfWork UoW, Counterparty client, DateTime newDeliveryDate, int orderId);
+		bool IfOrderDeliveryIsFirst(IUnitOfWork UoW, Counterparty client, int orderId);
 
 		OrderStatus[] GetOnClosingOrderStatuses();
 

--- a/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
@@ -85,6 +85,16 @@ namespace Vodovoz.EntityRepositories.Orders
 		/// <param name="count">Требуемое количество последних заказов.</param>
 		IList<Domain.Orders.Order> GetLatestOrdersForCounterparty(IUnitOfWork UoW, Counterparty client, int? count = null);
 
+		/// <summary>
+		/// Проверка необходима, если контракт ещё не был заключен (дата контракта равна первому заказу клиента),
+		/// и нужно изменить дату контракта при изменении даты доставки.
+		/// </summary>
+		/// <param name="UoW"></param>
+		/// <param name="client"></param>
+		/// <param name="newDeliveryDate"></param>
+		/// <returns></returns>
+		bool IfOrderDeliveryIsFirst(IUnitOfWork UoW, Counterparty client, DateTime newDeliveryDate, int orderId);
+
 		OrderStatus[] GetOnClosingOrderStatuses();
 
 		Domain.Orders.Order GetOrderOnDateAndDeliveryPoint(IUnitOfWork uow, DateTime date, DeliveryPoint deliveryPoint);

--- a/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
@@ -86,14 +86,16 @@ namespace Vodovoz.EntityRepositories.Orders
 		IList<Domain.Orders.Order> GetLatestOrdersForCounterparty(IUnitOfWork UoW, Counterparty client, int? count = null);
 
 		/// <summary>
-		/// Проверка необходима, если контракт ещё не был заключен (дата контракта равна первому заказу клиента),
-		/// и нужно изменить дату контракта при изменении даты доставки.
+		/// Проверка возможности изменения даты контракта при изменении даты доставки заказа.
+		/// Если дата первого заказа меньше newDeliveryDate и это - текущий изменяемый заказ - возвращает True.
+		/// Если первый заказ меньше newDeliveryDate и он не является текущим заказом - возвращает False.
 		/// </summary>
-		/// <param name="UoW"></param>
-		/// <param name="client"></param>
-		/// <param name="newDeliveryDate"></param>
-		/// <returns></returns>
-		bool IfOrderDeliveryIsFirst(IUnitOfWork UoW, Counterparty client, int orderId);
+		/// <param name="uow">IUnitOfWork</param>
+		/// <param name="client">Поиск заказов по этому контрагенту</param>
+		/// <param name="newDeliveryDate">Новая дата доставки заказа</param>
+		/// <param name="orderId">Текущий изменяемый заказ</param>
+		/// <returns>Возможность смены даты контракта</returns>
+		bool CanChangeContractDate(IUnitOfWork uow, Counterparty client, DateTime newDeliveryDate, int orderId);
 
 		OrderStatus[] GetOnClosingOrderStatuses();
 

--- a/VodovozBusiness/EntityRepositories/Orders/OrderSingletonRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Orders/OrderSingletonRepository.cs
@@ -334,30 +334,30 @@ namespace Vodovoz.EntityRepositories.Orders
 			else
 				return queryResult.List();
 		}
-
+		
 		/// <summary>
-		/// Проверка, если заказ клиента является первым.
+		/// Проверка возможности изменения даты контракта при изменении даты доставки заказа.
+		/// Если дата первого заказа меньше newDeliveryDate и это - текущий изменяемый заказ - возвращает True.
+		/// Если первый заказ меньше newDeliveryDate и он не является текущим заказом - возвращает False.
 		/// </summary>
-		/// <param name="UoW"></param>
-		/// <param name="client"></param>
-		/// <param name="newDeliveryDate"></param>
-		/// <returns></returns>
-		public bool IfOrderDeliveryIsFirst(IUnitOfWork UoW, Counterparty client, int orderId)
+		/// <param name="uow">IUnitOfWork</param>
+		/// <param name="client">Поиск заказов по этому контрагенту</param>
+		/// <param name="newDeliveryDate">Новая дата доставки заказа</param>
+		/// <param name="orderId">Текущий изменяемый заказ</param>
+		/// <returns>Возможность смены даты контракта</returns>
+		public bool CanChangeContractDate(IUnitOfWork uow, Counterparty client, DateTime newDeliveryDate, int orderId)
 		{
 			VodovozOrder orderAlias = null;
 			
-			var queryResult = UoW.Session.QueryOver(() => orderAlias)
+			var result = uow.Session.QueryOver(() => orderAlias)
 				.Where(() => orderAlias.Client == client)
 				.OrderBy(() => orderAlias.DeliveryDate).Asc
 				.List().FirstOrDefault();
-			
-			if(queryResult.Id == orderId)
+			if(result.DeliveryDate < newDeliveryDate && result.Id != orderId)
 			{
-				//Если не найдены заказы с более ранней датой доставки
-				return true;
+				return false;
 			}
-			//Если существуют заказы с более ранней датой доставки
-			return false;
+			return true;
 		}
 
 		/// <summary>

--- a/VodovozBusiness/EntityRepositories/Orders/OrderSingletonRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Orders/OrderSingletonRepository.cs
@@ -336,28 +336,28 @@ namespace Vodovoz.EntityRepositories.Orders
 		}
 
 		/// <summary>
-		/// Проверка необходима, если контракт ещё не был заключен (дата контракта равна первому заказу клиента),
-		/// и нужно изменить дату контракта при изменении даты доставки.
+		/// Проверка, если заказ клиента является первым.
 		/// </summary>
 		/// <param name="UoW"></param>
 		/// <param name="client"></param>
 		/// <param name="newDeliveryDate"></param>
 		/// <returns></returns>
-		public bool IfOrderDeliveryIsFirst(IUnitOfWork UoW, Counterparty client, DateTime newDeliveryDate, int orderId)
+		public bool IfOrderDeliveryIsFirst(IUnitOfWork UoW, Counterparty client, int orderId)
 		{
 			VodovozOrder orderAlias = null;
+			
 			var queryResult = UoW.Session.QueryOver(() => orderAlias)
 				.Where(() => orderAlias.Client == client)
-				.Where(() => orderAlias.DeliveryDate < newDeliveryDate)
-				.Where(()=>orderAlias.Id != orderId)
-				.List();
-			if(queryResult.Any())
+				.OrderBy(() => orderAlias.DeliveryDate).Asc
+				.List().FirstOrDefault();
+			
+			if(queryResult.Id == orderId)
 			{
-				//Если существуют заказы с более ранней датой доставки
-				return false;
+				//Если не найдены заказы с более ранней датой доставки
+				return true;
 			}
-			//Если не найдены заказы с более ранней датой доставки
-			return true;
+			//Если существуют заказы с более ранней датой доставки
+			return false;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Функционал на изменение даты контракта при изменении даты доставки (при ещё не сохраненном заказе уже сделано)
Если заказ уже был сохранен, но меняется дата доставки, дата контракта также будет изменена
Добавлена проверка на то, будет ли заказ с новой датой доставки первым в очереди
Выводится окно с предупреждением о изменении даты контракта