### PR TITLE
3684 Валидация на дублирующийся заказ вне текущей сессии

### DIFF
--- a/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -1162,7 +1162,7 @@ namespace Vodovoz
 			{
 				{ "NewStatus", OrderStatus.Accepted },
 				{ "IsCopiedFromUndelivery", templateOrder != null },//индикатор того, что заказ - копия, созданная из недовозов
-				{ "factory", uowFactory }
+				{ "uowFactory", uowFactory }
 			});
 
 			if(!Validate(validationContext))

--- a/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -34,6 +34,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Data.Bindings.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Autofac;
 using Vodovoz.Core;
 using Vodovoz.Core.DataService;
 using Vodovoz.Dialogs;
@@ -1153,14 +1154,20 @@ namespace Vodovoz
 		private bool ValidateAndFormOrder()
 		{
 			Entity.CheckAndSetOrderIsService();
-
-			ValidationContext validationContext = new ValidationContext(Entity, null, new Dictionary<object, object>{
+			
+			ILifetimeScope autofacScope = MainClass.AppDIContainer.BeginLifetimeScope();
+			var uowFactory = autofacScope.Resolve<IUnitOfWorkFactory>();
+			
+			ValidationContext validationContext = new ValidationContext(Entity, null, new Dictionary<object, object>
+			{
 				{ "NewStatus", OrderStatus.Accepted },
-				{ "IsCopiedFromUndelivery", templateOrder != null } //индикатор того, что заказ - копия, созданная из недовозов
+				{ "IsCopiedFromUndelivery", templateOrder != null },//индикатор того, что заказ - копия, созданная из недовозов
+				{ "factory", uowFactory }
 			});
 
 			if(!Validate(validationContext))
 			{
+				autofacScope.Dispose();
 				return false;
 			}
 
@@ -1168,6 +1175,7 @@ namespace Vodovoz
 				MessageDialogHelper.RunWarningDialog("Точка доставки не попадает ни в один из наших районов доставки. Пожалуйста, согласуйте стоимость доставки с руководителем и клиентом.");
 
 			OnFormOrderActions();
+			autofacScope.Dispose();
 			return true;
 		}
 

--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -991,6 +991,7 @@ namespace Vodovoz.Domain.Orders
 
 					//создание нескольких заказов на одну дату и точку доставки
 					if(!SelfDelivery && DeliveryPoint != null
+					                 && DeliveryDate.HasValue
 					                 && !ServicesConfig.CommonServices.CurrentPermissionService.ValidatePresetPermission("can_create_several_orders_for_date_and_deliv_point")
 					                 && validationContext.Items.ContainsKey("uowFactory")
 					                 && validationContext.Items.ContainsKey("IsCopiedFromUndelivery") 
@@ -1006,7 +1007,6 @@ namespace Vodovoz.Domain.Orders
 							            && !o.IsService).ToList();
 
 						if(!hasMaster
-						   && DeliveryDate.HasValue
 						   && orderCheckedOutsideSession.Any())
 						{
 							yield return new ValidationResult(

--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -1002,8 +1002,7 @@ namespace Vodovoz.Domain.Orders
 							.GetSameOrderForDateAndDeliveryPoint((IUnitOfWorkFactory)validationContext.Items["uowFactory"], DeliveryDate.Value,
 								DeliveryPoint)
 							.Where(o => o.Id != Id
-							   && !_orderRepository.GetGrantedStatusesToCreateSeveralOrders().Contains(o.OrderStatus)
-							   && !o.IsService).ToList();
+							            && !o.IsService).ToList();
 
 						if(!hasMaster
 						   && DeliveryDate.HasValue

--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -1001,12 +1001,11 @@ namespace Vodovoz.Domain.Orders
 						var orderCheckedOutsideSession = _orderRepository
 							.GetSameOrderForDateAndDeliveryPoint((IUnitOfWorkFactory)validationContext.Items["uowFactory"], DeliveryDate.Value,
 								DeliveryPoint)
-							.Where(o => o.Id != Id
-							            && !o.IsService).ToList();
+							.Where(o => o.Id != Id && !o.IsService).ToList();
 
 						if(!hasMaster
 						   && DeliveryDate.HasValue
-						   && orderCheckedOutsideSession.Count>0)
+						   && orderCheckedOutsideSession.Any())
 						{
 							yield return new ValidationResult(
 								string.Format("Создать заказ нельзя, т.к. для этой даты и точки доставки уже был создан заказ {0}",orderCheckedOutsideSession.FirstOrDefault().Id),

--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -999,9 +999,11 @@ namespace Vodovoz.Domain.Orders
 						bool hasMaster = ObservableOrderItems.Any(i => i.Nomenclature.Category == NomenclatureCategory.master);
 
 						var orderCheckedOutsideSession = _orderRepository
-							.GetSameOrderForDateAndDeliveryPoint((IUnitOfWorkFactory)validationContext.Items["uowFactory"], DeliveryDate.Value,
-								DeliveryPoint)
-							.Where(o => o.Id != Id && !o.IsService).ToList();
+							.GetSameOrderForDateAndDeliveryPoint((IUnitOfWorkFactory)validationContext.Items["uowFactory"], 
+								DeliveryDate.Value, DeliveryPoint)
+							.Where(o => o.Id != Id 
+							            && !_orderRepository.GetGrantedStatusesToCreateSeveralOrders().Contains(o.OrderStatus) 
+							            && !o.IsService).ToList();
 
 						if(!hasMaster
 						   && DeliveryDate.HasValue

--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -999,9 +999,11 @@ namespace Vodovoz.Domain.Orders
 						bool hasMaster = ObservableOrderItems.Any(i => i.Nomenclature.Category == NomenclatureCategory.master);
 
 						var orderCheckedOutsideSession = _orderRepository
-							.GetSameOrderOutsideTransaction((IUnitOfWorkFactory) validationContext.Items["uowFactory"], DeliveryDate.Value,
+							.GetSameOrderForDateAndDeliveryPoint((IUnitOfWorkFactory)validationContext.Items["uowFactory"], DeliveryDate.Value,
 								DeliveryPoint)
-							.Where(o => o.Id != Id).ToList();
+							.Where(o => o.Id != Id
+							   && !_orderRepository.GetGrantedStatusesToCreateSeveralOrders().Contains(o.OrderStatus)
+							   && !o.IsService).ToList();
 
 						if(!hasMaster
 						   && DeliveryDate.HasValue

--- a/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
@@ -74,7 +74,7 @@ namespace Vodovoz.EntityRepositories.Orders
 		/// <param name="UoW">IUnitOfWork</param>
 		/// <param name="deliveryPoint">Точка доставки.</param>
 		/// <param name="count">Требуемое количество последних заказов.</param>
-		IList<Domain.Orders.Order> GetLatestOrdersForDeliveryPoint(IUnitOfWork UoW, DeliveryPoint deliveryPoint, int? count = null);
+		IList<Domain.Orders.Order> GetSameOrderForDateAndDeliveryPoint(IUnitOfWorkFactory UoW, DeliveryPoint deliveryPoint, int? count = null);
 
 		/// <summary>
 		/// Список последних заказов для контрагента .

--- a/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
@@ -74,7 +74,7 @@ namespace Vodovoz.EntityRepositories.Orders
 		/// <param name="UoW">IUnitOfWork</param>
 		/// <param name="deliveryPoint">Точка доставки.</param>
 		/// <param name="count">Требуемое количество последних заказов.</param>
-		IList<Domain.Orders.Order> GetSameOrderForDateAndDeliveryPoint(IUnitOfWorkFactory UoW, DeliveryPoint deliveryPoint, int? count = null);
+		IList<Domain.Orders.Order> GetLatestOrdersForDeliveryPoint(IUnitOfWork UoW, DeliveryPoint deliveryPoint, int? count = null);
 
 		/// <summary>
 		/// Список последних заказов для контрагента .
@@ -100,7 +100,7 @@ namespace Vodovoz.EntityRepositories.Orders
 		OrderStatus[] GetOnClosingOrderStatuses();
 
 		Domain.Orders.Order GetOrderOnDateAndDeliveryPoint(IUnitOfWork uow, DateTime date, DeliveryPoint deliveryPoint);
-		IList<Domain.Orders.Order> GetSameOrderOutsideTransaction(IUnitOfWorkFactory uow, DateTime date, DeliveryPoint deliveryPoint);
+		IList<Domain.Orders.Order> GetSameOrderForDateAndDeliveryPoint(IUnitOfWorkFactory uow, DateTime date, DeliveryPoint deliveryPoint);
         Domain.Orders.Order GetOrder(IUnitOfWork unitOfWork, int orderId);
         IList<Domain.Orders.Order> GetOrdersBetweenDates(IUnitOfWork UoW, DateTime startDate, DateTime endDate);
 

--- a/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
@@ -100,6 +100,7 @@ namespace Vodovoz.EntityRepositories.Orders
 		OrderStatus[] GetOnClosingOrderStatuses();
 
 		Domain.Orders.Order GetOrderOnDateAndDeliveryPoint(IUnitOfWork uow, DateTime date, DeliveryPoint deliveryPoint);
+		IList<Domain.Orders.Order> GetSameOrderOutsideTransaction(IUnitOfWorkFactory uow, DateTime date, DeliveryPoint deliveryPoint);
         Domain.Orders.Order GetOrder(IUnitOfWork unitOfWork, int orderId);
         IList<Domain.Orders.Order> GetOrdersBetweenDates(IUnitOfWork UoW, DateTime startDate, DateTime endDate);
 

--- a/VodovozBusiness/EntityRepositories/Orders/OrderSingletonRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Orders/OrderSingletonRepository.cs
@@ -430,11 +430,12 @@ namespace Vodovoz.EntityRepositories.Orders
 					  .List().FirstOrDefault();
 		}
 		
-		public IList<Domain.Orders.Order> GetSameOrderOutsideTransaction(IUnitOfWorkFactory uowFactory, DateTime date, DeliveryPoint deliveryPoint)
+		public IList<Domain.Orders.Order> GetSameOrderForDateAndDeliveryPoint(IUnitOfWorkFactory uowFactory, DateTime date, DeliveryPoint deliveryPoint)
 		{
 			var uow = uowFactory.CreateWithoutRoot();
 			
-			var notSupportedStatuses = new OrderStatus[] {
+			var notSupportedStatuses = new OrderStatus[] 
+			{
 				OrderStatus.NewOrder,
 				OrderStatus.Canceled,
 				OrderStatus.NotDelivered

--- a/VodovozBusiness/EntityRepositories/Orders/OrderSingletonRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Orders/OrderSingletonRepository.cs
@@ -434,16 +434,7 @@ namespace Vodovoz.EntityRepositories.Orders
 		{
 			var uow = uowFactory.CreateWithoutRoot();
 			
-			var notSupportedStatuses = new OrderStatus[] 
-			{
-				OrderStatus.NewOrder,
-				OrderStatus.Canceled,
-				OrderStatus.NotDelivered,
-				OrderStatus.DeliveryCanceled,
-			};
-
 			return uow.Session.QueryOver<VodovozOrder>()
-				.WhereRestrictionOn(x => x.OrderStatus).Not.IsIn(notSupportedStatuses)
 				.Where(x => x.DeliveryDate == date)
 				.Where(x => x.DeliveryPoint.Id == deliveryPoint.Id)
 				.List();

--- a/VodovozBusiness/EntityRepositories/Orders/OrderSingletonRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Orders/OrderSingletonRepository.cs
@@ -429,6 +429,23 @@ namespace Vodovoz.EntityRepositories.Orders
 					  .Where(x => x.DeliveryPoint.Id == deliveryPoint.Id)
 					  .List().FirstOrDefault();
 		}
+		
+		public IList<Domain.Orders.Order> GetSameOrderOutsideTransaction(IUnitOfWorkFactory uowFactory, DateTime date, DeliveryPoint deliveryPoint)
+		{
+			var uow = uowFactory.CreateWithoutRoot();
+			
+			var notSupportedStatuses = new OrderStatus[] {
+				OrderStatus.NewOrder,
+				OrderStatus.Canceled,
+				OrderStatus.NotDelivered
+			};
+
+			return uow.Session.QueryOver<VodovozOrder>()
+				.WhereRestrictionOn(x => x.OrderStatus).Not.IsIn(notSupportedStatuses)
+				.Where(x => x.DeliveryDate == date)
+				.Where(x => x.DeliveryPoint.Id == deliveryPoint.Id)
+				.List();
+		}
 
 		public bool IsBottleStockExists(IUnitOfWork uow, Counterparty counterparty)
 		{

--- a/VodovozBusiness/EntityRepositories/Orders/OrderSingletonRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Orders/OrderSingletonRepository.cs
@@ -438,7 +438,8 @@ namespace Vodovoz.EntityRepositories.Orders
 			{
 				OrderStatus.NewOrder,
 				OrderStatus.Canceled,
-				OrderStatus.NotDelivered
+				OrderStatus.NotDelivered,
+				OrderStatus.DeliveryCanceled,
 			};
 
 			return uow.Session.QueryOver<VodovozOrder>()


### PR DESCRIPTION
В репозитории создан метод проверки уже существующего заказа. 
Метод использует новый UoW, который создается на месте для предотвращения транзакции. 
UoW создается фабрикой, которая резолвится автофаком перед валидацией и передается в контекст.
Из контекста фабрика отправляется уже в новый метод.
Новый метод используется в валидации, сравнивается ID текущего заказа с найденными, если не равен - найден уже созданный заказ и валидация не проходит.