### PR TITLE
Переименовал вьюмодель, чтобы быстро поправить ошибку

### DIFF
--- a/Vodovoz/Infrastructure/Mango/MangoManager.cs
+++ b/Vodovoz/Infrastructure/Mango/MangoManager.cs
@@ -248,7 +248,7 @@ namespace Vodovoz.Infrastructure.Mango
 				CurrentPage = navigation.OpenViewModel<CounterpartyTalkViewModel, MangoManager>(null, this);
 				CurrentPage.PageClosed += CurrentPage_PageClosed;
 			} else {
-				CurrentPage = navigation.OpenViewModel<UnknownTalkViewModel, MangoManager>(null, this);
+				CurrentPage = navigation.OpenViewModel<UnknowTalkViewModel, MangoManager>(null, this);
 				CurrentPage.PageClosed += CurrentPage_PageClosed;
 			}
 			ConnectionState = ConnectionState.Talk;

--- a/Vodovoz/ViewModels/Mango/Talks/UnknowTalkViewModel.cs
+++ b/Vodovoz/ViewModels/Mango/Talks/UnknowTalkViewModel.cs
@@ -24,7 +24,7 @@ using Vodovoz.ViewModels.Complaints;
 
 namespace Vodovoz.ViewModels.Mango.Talks
 {
-	public class UnknownTalkViewModel : TalkViewModelBase
+	public class UnknowTalkViewModel : TalkViewModelBase
 	{
 		private readonly ITdiCompatibilityNavigation _tdiNavigation;
 		private readonly IInteractiveQuestion _interactive;
@@ -33,7 +33,7 @@ namespace Vodovoz.ViewModels.Mango.Talks
 		private readonly INomenclatureRepository _nomenclatureRepository;
 		private readonly IUnitOfWork _uow;
 		
-		public UnknownTalkViewModel(IUnitOfWorkFactory unitOfWorkFactory, 
+		public UnknowTalkViewModel(IUnitOfWorkFactory unitOfWorkFactory, 
 			ITdiCompatibilityNavigation navigation, 
 			IInteractiveQuestion interactive,
 			MangoManager manager,

--- a/Vodovoz/Views/Mango/Talks/UnknowTalkView.cs
+++ b/Vodovoz/Views/Mango/Talks/UnknowTalkView.cs
@@ -4,9 +4,9 @@ using Vodovoz.ViewModels.Mango.Talks;
 
 namespace Vodovoz.Views.Mango.Talks
 {
-	public partial class UnknowTalkView : DialogViewBase<UnknownTalkViewModel>
+	public partial class UnknowTalkView : DialogViewBase<UnknowTalkViewModel>
 	{
-		public UnknowTalkView(UnknownTalkViewModel viewModel) : base(viewModel)
+		public UnknowTalkView(UnknowTalkViewModel viewModel) : base(viewModel)
 		{
 			this.Build();
 			Configure();

--- a/Vodovoz/Vodovoz.csproj
+++ b/Vodovoz/Vodovoz.csproj
@@ -1476,7 +1476,7 @@
     <Compile Include="Views\Mango\IncomingCallView.cs" />
     <Compile Include="gtk-gui\Vodovoz.Views.Mango.IncomingCallView.cs" />
     <Compile Include="ViewModels\Mango\Talks\CounterpartyTalkViewModel.cs" />
-    <Compile Include="ViewModels\Mango\Talks\UnknownTalkViewModel.cs" />
+    <Compile Include="ViewModels\Mango\Talks\UnknowTalkViewModel.cs" />
     <Compile Include="Views\Mango\Talks\CounterpartyTalkView.cs" />
     <Compile Include="Views\Mango\Talks\UnknowTalkView.cs" />
     <Compile Include="ViewModels\Mango\Talks\TalkViewModelBase.cs" />


### PR DESCRIPTION
Чтобы быстро исправить ошибку - вернул старое имя вью модели.
Чуть позже исправлю нормально, с переименованием вьюхи