### PR TITLE
3532 Фикс ошибки при создании "Причины отсутствия переноса"

### DIFF
--- a/VodovozBusiness/Domain/Orders/UndeliveryTransferAbsenceReason.cs
+++ b/VodovozBusiness/Domain/Orders/UndeliveryTransferAbsenceReason.cs
@@ -55,7 +55,7 @@ namespace Vodovoz.Domain.Orders
 				yield return new ValidationResult("Название должно быть указано.", new[] { nameof(Name) });
 			}
 
-			if(Name.Length > 50)
+			if(Name?.Length > 50)
 			{
 				yield return new ValidationResult($"Превышена максимально допустимая длина названия ({Name.Length}/50).",
 					new[] { nameof(Name) });


### PR DESCRIPTION
Если не заполнить поле «Название» при создании причины выскакивала ошибка.