### PR TITLE
3642 Удаление возвратного платежа при восстановлении заказа в работу

### DIFF
--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -2753,7 +2753,7 @@ namespace Vodovoz.Domain.Orders
 				}
 
 				UoW.Delete(refundToDelete);
-				var totalPayed = paymentItems.Select(pi => pi.Sum).Sum();
+				var totalPayed = paymentItems.Sum(pi => pi.Sum);
 
 				OrderPaymentStatus = ActualTotalSum > totalPayed
 					? OrderPaymentStatus.PartiallyPaid
@@ -2775,7 +2775,7 @@ namespace Vodovoz.Domain.Orders
 				return;
 			}
 
-			var totalPayed = paymentItems.Select(pi => pi.Sum).Sum();
+			var totalPayed = paymentItems.Sum(pi => pi.Sum);
 
 			OrderPaymentStatus = totalPayed == 0
 				? OrderPaymentStatus.UnPaid

--- a/VodovozBusiness/Domain/Payments/Payment.cs
+++ b/VodovozBusiness/Domain/Payments/Payment.cs
@@ -172,6 +172,14 @@ namespace Vodovoz.Domain.Payments
 			set => SetField(ref counterpartyCorrespondentAcc, value);
 		}
 
+		private Payment _refundedPayment;
+		[Display(Name = "Возвращаемый платеж")]
+		public virtual Payment RefundedPayment
+		{
+			get => _refundedPayment;
+			set => SetField(ref _refundedPayment, value);
+		}
+
 		public virtual string NumOrders { get; set; }
 
 		public Payment() { }
@@ -287,8 +295,9 @@ namespace Vodovoz.Domain.Payments
 				PaymentPurpose = $"Возврат суммы оплаты заказа №{orderId} на баланс клиента",
 				Organization = Organization,
 				Counterparty = Counterparty,
-				CounterpartyName = counterpartyName,
-				Status = PaymentState.undistributed
+				CounterpartyName = CounterpartyName,
+				Status = PaymentState.undistributed,
+				RefundedPayment = this
 			};
 		}
 

--- a/VodovozBusiness/EntityRepositories/Payments/IPaymentsRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Payments/IPaymentsRepository.cs
@@ -17,5 +17,6 @@ namespace Vodovoz.EntityRepositories.Payments
 		decimal GetCounterpartyLastBalance(IUnitOfWork uow, int counterpartyId);
 		IList<Payment> GetAllUndistributedPayments(IUnitOfWork uow, IProfitCategoryProvider profitCategoryProvider);
 		IList<Payment> GetAllDistributedPayments(IUnitOfWork uow);
+		Payment GetRefundPaymentByRefundedPaymentId(IUnitOfWork uow, int refundedPaymentId);
 	}
 }

--- a/VodovozBusiness/EntityRepositories/Payments/IPaymentsRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Payments/IPaymentsRepository.cs
@@ -17,6 +17,6 @@ namespace Vodovoz.EntityRepositories.Payments
 		decimal GetCounterpartyLastBalance(IUnitOfWork uow, int counterpartyId);
 		IList<Payment> GetAllUndistributedPayments(IUnitOfWork uow, IProfitCategoryProvider profitCategoryProvider);
 		IList<Payment> GetAllDistributedPayments(IUnitOfWork uow);
-		Payment GetRefundPaymentByRefundedPaymentId(IUnitOfWork uow, int refundedPaymentId);
+		Payment GetRefundPayment(IUnitOfWork uow, int refundedPaymentId);
 	}
 }

--- a/VodovozBusiness/EntityRepositories/Payments/PaymentsRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Payments/PaymentsRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using NHibernate.Criterion;
 using NHibernate.Transform;
 using QS.DomainModel.UoW;
@@ -90,6 +91,15 @@ namespace Vodovoz.EntityRepositories.Payments
 									.List();
 
 			return distributedPayments;
+		}
+
+		public Payment GetRefundPaymentByRefundedPaymentId(IUnitOfWork uow, int refundedPaymentId)
+		{
+			var refund = uow.Session.QueryOver<Payment>()
+				.Where(p => p.RefundedPayment.Id == refundedPaymentId)
+				.List()
+				.FirstOrDefault();
+			return refund;
 		}
 	}
 }

--- a/VodovozBusiness/EntityRepositories/Payments/PaymentsRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Payments/PaymentsRepository.cs
@@ -93,7 +93,7 @@ namespace Vodovoz.EntityRepositories.Payments
 			return distributedPayments;
 		}
 
-		public Payment GetRefundPaymentByRefundedPaymentId(IUnitOfWork uow, int refundedPaymentId)
+		public Payment GetRefundPayment(IUnitOfWork uow, int refundedPaymentId)
 		{
 			var refund = uow.Session.QueryOver<Payment>()
 				.Where(p => p.RefundedPayment.Id == refundedPaymentId)

--- a/VodovozBusiness/EntityRepositories/Payments/PaymentsRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Payments/PaymentsRepository.cs
@@ -97,8 +97,7 @@ namespace Vodovoz.EntityRepositories.Payments
 		{
 			var refund = uow.Session.QueryOver<Payment>()
 				.Where(p => p.RefundedPayment.Id == refundedPaymentId)
-				.List()
-				.FirstOrDefault();
+				.SingleOrDefault();
 			return refund;
 		}
 	}

--- a/VodovozBusiness/HibernateMapping/Accounting/PaymentMap.cs
+++ b/VodovozBusiness/HibernateMapping/Accounting/PaymentMap.cs
@@ -30,7 +30,8 @@ namespace Vodovoz.HibernateMapping.Accounting
 			References(x => x.Organization).Column("organization_id");
 			References(x => x.OrganizationAccount).Column("organization_account_id");
 			References(x => x.ProfitCategory).Column("profit_category_id");
-			References(x => x.CashlessMovementOperation).Column("cashless_movement_operation_id");
+			References(x => x.CashlessMovementOperation).Column("cashless_movement_operation_id")
+				.Cascade.AllDeleteOrphan();
 			References(x => x.RefundedPayment).Column("refunded_payment_id");
 
 			HasMany(x => x.PaymentItems).Cascade.AllDeleteOrphan().Inverse().LazyLoad().KeyColumn("payment_id");

--- a/VodovozBusiness/HibernateMapping/Accounting/PaymentMap.cs
+++ b/VodovozBusiness/HibernateMapping/Accounting/PaymentMap.cs
@@ -31,6 +31,7 @@ namespace Vodovoz.HibernateMapping.Accounting
 			References(x => x.OrganizationAccount).Column("organization_account_id");
 			References(x => x.ProfitCategory).Column("profit_category_id");
 			References(x => x.CashlessMovementOperation).Column("cashless_movement_operation_id");
+			References(x => x.RefundedPayment).Column("refunded_payment_id");
 
 			HasMany(x => x.PaymentItems).Cascade.AllDeleteOrphan().Inverse().LazyLoad().KeyColumn("payment_id");
 		}

--- a/VodovozBusiness/HibernateMapping/Payments/PaymentItemMap.cs
+++ b/VodovozBusiness/HibernateMapping/Payments/PaymentItemMap.cs
@@ -14,7 +14,8 @@ namespace Vodovoz.HibernateMapping.Payments
 
 			References(x => x.Order).Column("order_id");
 			References(x => x.Payment).Column("payment_id");
-			References(x => x.CashlessMovementOperation).Column("cashless_movement_operation_id");
+			References(x => x.CashlessMovementOperation).Column("cashless_movement_operation_id")
+				.Cascade.AllDeleteOrphan();
 		}
 	}
 }


### PR DESCRIPTION
При переводе адреса МЛ в статусы В пути и Выполнен из Недовоз или Доставка отменена, если ассоциированный с адресом заказ - заказ с оплатой по безналу, проверяется наличие возврата, который удаляется и заказ меняет статус оплаты