### PR TITLE
3749 Приём-передача терминала с 1 ходки на 2

### DIFF
--- a/Vodovoz/Dialogs/Logistic/RouteListAddressesTransferringDlg.cs
+++ b/Vodovoz/Dialogs/Logistic/RouteListAddressesTransferringDlg.cs
@@ -18,6 +18,7 @@ using Vodovoz.Core.DataService;
 using Vodovoz.Domain.Client;
 using Vodovoz.Domain.Documents;
 using Vodovoz.Domain.Documents.DriverTerminal;
+using Vodovoz.Domain.Documents.DriverTerminalTransfer;
 using Vodovoz.Domain.Goods;
 using Vodovoz.Domain.Logistic;
 using Vodovoz.Domain.Operations;
@@ -582,7 +583,7 @@ namespace Vodovoz
 						OperationTime = DateTime.Now
 					};
 
-					var driverTerminalTransferDocument = new DriverTerminalTransferDocument()
+					var driverTerminalTransferDocument = new AnotherDriverTerminalTransferDocument()
 					{
 						Author = _employeeService.GetEmployeeForUser(UoW, _commonServices.UserService.CurrentUserId),
 						CreateDate = DateTime.Now,
@@ -651,7 +652,7 @@ namespace Vodovoz
 						OperationTime = DateTime.Now
 					};
 
-					var driverTerminalTransferDocument = new DriverTerminalTransferDocument()
+					var driverTerminalTransferDocument = new AnotherDriverTerminalTransferDocument()
 					{
 						Author = _employeeService.GetEmployeeForUser(UoW, _commonServices.UserService.CurrentUserId),
 						CreateDate = DateTime.Now,

--- a/Vodovoz/Dialogs/Logistic/RouteListControlDlg.cs
+++ b/Vodovoz/Dialogs/Logistic/RouteListControlDlg.cs
@@ -92,7 +92,7 @@ namespace Vodovoz.Dialogs.Logistic
 		private void UpdateLists()
 		{
 			var goods = _routeListRepository.GetGoodsAndEquipsInRL(UoW, Entity);
-			var notLoadedNomenclatures = Entity.NotLoadedNomenclatures(true);
+			var notLoadedNomenclatures = Entity.NotLoadedNomenclatures(true, _baseParametersProvider.GetNomenclatureIdForTerminal);
 			
 			ObservableNotLoadedList = new GenericObservableList<RouteListControlNotLoadedNode>(notLoadedNomenclatures);
 

--- a/Vodovoz/Dialogs/Logistic/RouteListCreateDlg.cs
+++ b/Vodovoz/Dialogs/Logistic/RouteListCreateDlg.cs
@@ -307,7 +307,6 @@ namespace Vodovoz
 					if(selfDriverTerminalTransferDocument != null)
 					{
 						UoW.Delete(selfDriverTerminalTransferDocument);
-						UoW.Commit();
 					}
 				}
 

--- a/Vodovoz/Dialogs/Logistic/RouteListCreateDlg.cs
+++ b/Vodovoz/Dialogs/Logistic/RouteListCreateDlg.cs
@@ -22,6 +22,7 @@ using Vodovoz.Dialogs;
 using Vodovoz.Domain.Cash;
 using Vodovoz.Domain.Client;
 using Vodovoz.Domain.Documents.DriverTerminal;
+using Vodovoz.Domain.Documents.DriverTerminalTransfer;
 using Vodovoz.Domain.Employees;
 using Vodovoz.Domain.Logistic;
 using Vodovoz.Domain.WageCalculation.CalculationServices.RouteList;
@@ -65,6 +66,7 @@ namespace Vodovoz
 
 		private bool _isEditable;
 		private bool _canClose = true;
+		private Employee _oldDriver;
 
 		protected bool IsEditable
 		{
@@ -244,6 +246,8 @@ namespace Vodovoz
 			{
 				labelTerminalCondition.LabelProp += $"{Entity.DriverTerminalCondition?.GetEnumTitle() ?? "неизвестно"}";
 			}
+
+			_oldDriver = Entity.Driver;
 		}
 
 		private void YspeccomboboxCashSubdivision_ItemSelected(object sender, Gamma.Widgets.ItemSelectedEventArgs e)
@@ -293,6 +297,22 @@ namespace Vodovoz
 			}
 
 			Entity.CalculateWages(_wageParameterService);
+
+			if(_oldDriver != Entity.Driver)
+			{
+				if(_oldDriver != null)
+				{
+					var selfDriverTerminalTransferDocument = _routeListRepository.GetSelfDriverTerminalTransferDocument(UoW, _oldDriver, Entity);
+
+					if(selfDriverTerminalTransferDocument != null)
+					{
+						UoW.Delete(selfDriverTerminalTransferDocument);
+						UoW.Commit();
+					}
+				}
+
+				_oldDriver = Entity.Driver;
+			}
 
 			_logger.Info("Сохраняем маршрутный лист...");
 			UoWGeneric.Save();

--- a/Vodovoz/JournalViewModels/RouteListWorkingJournalViewModel.cs
+++ b/Vodovoz/JournalViewModels/RouteListWorkingJournalViewModel.cs
@@ -10,9 +10,11 @@ using QS.Project.Journal;
 using QS.Services;
 using System;
 using System.Linq;
+using NHibernate.Linq;
 using Vodovoz.Core.DataService;
 using Vodovoz.Domain.Cash;
 using Vodovoz.Domain.Documents.DriverTerminal;
+using Vodovoz.Domain.Documents.DriverTerminalTransfer;
 using Vodovoz.Domain.Employees;
 using Vodovoz.Domain.Logistic;
 using Vodovoz.Domain.Sale;
@@ -459,6 +461,26 @@ namespace Vodovoz.JournalViewModels
 							$"\n-----" +
 							"\n" + string.Join("\n", changesToOrders.Select(pair => $"Заказ №{pair.Key} - {pair.Value}руб.")),
 							commonServices.PermissionService);
+					}
+				}
+			));
+
+			PopupActionsList.Add(new JournalAction(
+				"Перенести терминал на вторую ходку",
+				(selectedItems) =>
+				{
+					var userPermission = commonServices.PermissionService.ValidateUserPermission(
+						typeof(SelfDriverTerminalTransferDocument), commonServices.UserService.CurrentUserId);
+
+					return userPermission.CanCreate;
+				},
+				(selectedItems) => true,
+				(selectedItems) =>
+				{
+					if(selectedItems.FirstOrDefault() is RouteListJournalNode selectedNode)
+					{
+						var routeList = UoW.GetById<RouteList>(selectedNode.Id);
+						routeList?.CreateSelfDriverTerminalTransferDocument();
 					}
 				}
 			));

--- a/Vodovoz/Reports/Store/CarUnloadDoc.rdl
+++ b/Vodovoz/Reports/Store/CarUnloadDoc.rdl
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Report xmlns="http://schemas.microsoft.com/sqlserver/reporting/2005/01/reportdefinition" xmlns:rd="http://schemas.microsoft.com/SQLServer/reporting/reportdesigner">
-  <Description>
-  </Description>
-  <Author>
-  </Author>
+  <Description></Description>
+  <Author></Author>
   <PageHeight>11in</PageHeight>
   <PageWidth>8.5in</PageWidth>
   <DataSources>
@@ -177,6 +175,47 @@ WHERE
         </Field>
       </Fields>
     </DataSet>
+    <DataSet Name="SelfTerminalTransfer" >
+      <Query>
+        <DataSourceName>DS1</DataSourceName>
+        <CommandText>WITH RECURSIVE cte (routelist_from_id, routelist_to_id) AS (
+	SELECT		
+				dttd.routelist_from_id,
+				dttd.routelist_to_id
+	FROM 
+				driver_terminal_transfer_documents dttd
+	INNER JOIN
+				store_car_unload_documents scud
+			ON
+				scud.route_list_id = dttd.routelist_to_id
+	WHERE
+				scud.id = @id
+UNION ALL
+	SELECT		
+				dttd.routelist_from_id,
+				dttd.routelist_to_id
+	FROM 
+				driver_terminal_transfer_documents dttd
+	INNER JOIN
+				cte
+			ON
+				dttd.routelist_to_id = cte.routelist_from_id
+)
+SELECT			CONCAT('Внимание! Терминал был перенесён из МЛ ',  GROUP_CONCAT(routelist_from_id SEPARATOR ' ← '), '.') AS self_transfers
+FROM			cte;</CommandText>
+        <QueryParameters>
+          <QueryParameter Name="@id">
+            <Value>={?id}</Value>
+          </QueryParameter>
+        </QueryParameters>
+      </Query>
+      <Fields>
+        <Field Name="self_transfers">
+          <DataField>self_transfers</DataField>
+          <TypeName>System.String</TypeName>
+        </Field>
+      </Fields>
+    </DataSet>
   </DataSets>
   <PageHeader>
     <Height>0.0pt</Height>
@@ -288,8 +327,8 @@ WHERE
                         <BorderColor />
                         <BorderWidth />
                         <FontSize>11pt</FontSize>
-                        <PaddingTop >2pt</PaddingTop>
-                        <PaddingBottom >2pt</PaddingBottom>
+                        <PaddingTop>2pt</PaddingTop>
+                        <PaddingBottom>2pt</PaddingBottom>
                       </Style>
                     </Textbox>
                   </ReportItems>
@@ -342,6 +381,8 @@ WHERE
           <BorderStyle>
             <Default>Solid</Default>
           </BorderStyle>
+          <BorderColor  />
+          <BorderWidth  />
         </Style>
         <TableColumns>
           <TableColumn>
@@ -365,8 +406,7 @@ WHERE
                 <TableCell>
                   <ReportItems>
                     <Textbox Name="Textbox10">
-                      <Value>
-                      </Value>
+                      <Value></Value>
                       <Style xmlns="http://schemas.microsoft.com/sqlserver/reporting/2005/01/reportdefinition">
                         <BorderStyle>
                           <Default>None</Default>
@@ -383,8 +423,7 @@ WHERE
                 <TableCell>
                   <ReportItems>
                     <Textbox Name="Textbox11">
-                      <Value>
-                      </Value>
+                      <Value></Value>
                       <Style xmlns="http://schemas.microsoft.com/sqlserver/reporting/2005/01/reportdefinition">
                         <BorderStyle>
                           <Default>None</Default>
@@ -718,8 +757,8 @@ WHERE
         <Width>261.19pt</Width>
         <Value>= "____________________ (" + First({storekeeper}, "Doc") + ")"</Value>
         <ZIndex>1</ZIndex>
-        <Left>133.7pt</Left>
-        <Top>207.0pt</Top>
+        <Left>133.70pt</Left>
+        <Top>207.00pt</Top>
         <Style>
           <BorderStyle />
           <BorderColor />
@@ -727,8 +766,28 @@ WHERE
           <FontSize>11pt</FontSize>
         </Style>
       </Textbox>
+      <Textbox Name="Textbox7" >
+        <Height>21.00pt</Height>
+        <Width>537.20pt</Width>
+        <Value>=First({self_transfers}, "SelfTerminalTransfer")</Value>
+        <ZIndex>1</ZIndex>
+        <Left>7.30pt</Left>
+        <Top>249.30pt</Top>
+        <CanGrow>true</CanGrow>
+        <CanShrink>true</CanShrink>
+        <Style>
+          <BorderStyle />
+          <BorderColor />
+          <BorderWidth />
+          <FontFamily>Arial</FontFamily>
+          <FontSize>12pt</FontSize>
+          <FontWeight>Bold</FontWeight>
+          <TextAlign>Left</TextAlign>
+          <VerticalAlign>Middle</VerticalAlign>
+        </Style>
+      </Textbox>
     </ReportItems>
-    <Height>229.3pt</Height>
+    <Height>337.0pt</Height>
   </Body>
   <PageFooter>
     <Height>0.0pt</Height>
@@ -746,8 +805,7 @@ WHERE
       <Nullable>false</Nullable>
       <AllowBlank>false</AllowBlank>
       <MultiValue>false</MultiValue>
-      <Prompt>
-      </Prompt>
+      <Prompt></Prompt>
     </ReportParameter>
   </ReportParameters>
 </Report>

--- a/Vodovoz/Representations/RouteListsVM.cs
+++ b/Vodovoz/Representations/RouteListsVM.cs
@@ -6,7 +6,9 @@ using Dialogs.Logistic;
 using Gamma.ColumnConfig;
 using Gamma.Utilities;
 using Gtk;
+using NHibernate;
 using NHibernate.Criterion;
+using NHibernate.Linq;
 using NHibernate.Transform;
 using QS.Dialog.Gtk;
 using QS.Dialog.GtkUI;
@@ -37,6 +39,7 @@ using Vodovoz.Dialogs.OrderWidgets;
 using Vodovoz.EntityRepositories.Cash;
 using Vodovoz.EntityRepositories.Logistic;
 using Vodovoz.Domain.Documents.DriverTerminal;
+using Vodovoz.Domain.Documents.DriverTerminalTransfer;
 using Vodovoz.EntityRepositories.Store;
 using Vodovoz.EntityRepositories.Undeliveries;
 using Vodovoz.JournalViewers;
@@ -640,6 +643,25 @@ namespace Vodovoz.ViewModel
 						}
 					},
 					(selectedItems) => selectedItems.Any(x => FuelIssuingStatuses.Contains((x as RouteListsVMNode).StatusEnum))
+				));
+
+				result.Add(JournalPopupItemFactory.CreateNewAlwaysVisible(
+					"Перенести терминал на вторую ходку",
+					(selectedItems) =>
+					{
+						if(selectedItems.FirstOrDefault() is RouteListsVMNode selectedNode)
+						{
+							var routeList = UoW.GetById<RouteList>(selectedNode.Id);
+							routeList?.CreateSelfDriverTerminalTransferDocument();
+						}
+					},
+					(selectedItems) =>
+					{
+						var userPermission = ServicesConfig.CommonServices.PermissionService.ValidateUserPermission(
+							typeof(SelfDriverTerminalTransferDocument), ServicesConfig.UserService.CurrentUserId);
+
+						return userPermission.CanCreate;
+					}
 				));
 
 				return result;

--- a/VodovozBusiness/Domain/Documents/DriverTerminalTransfer/AnotherDriverTerminalTransferDocument.cs
+++ b/VodovozBusiness/Domain/Documents/DriverTerminalTransfer/AnotherDriverTerminalTransferDocument.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using QS.DomainModel.Entity;
+using QS.DomainModel.Entity.EntityPermissions;
+using QS.HistoryLog;
+using Vodovoz.Domain.Employees;
+using Vodovoz.Domain.Logistic;
+using Vodovoz.Domain.Operations;
+
+namespace Vodovoz.Domain.Documents.DriverTerminalTransfer
+{
+	[Appellative(Gender = GrammaticalGender.Masculine,
+		Nominative = "документ переноса терминала другому водителю",
+		NominativePlural = "документы переноса терминалов другому водителю")]
+	[EntityPermission]
+	[HistoryTrace]
+	public class AnotherDriverTerminalTransferDocument : DriverTerminalTransferDocumentBase
+	{
+		private EmployeeNomenclatureMovementOperation _employeeNomenclatureMovementOperationFrom;
+		private EmployeeNomenclatureMovementOperation _employeeNomenclatureMovementOperationTo;
+
+		public virtual EmployeeNomenclatureMovementOperation EmployeeNomenclatureMovementOperationFrom
+		{
+			get => _employeeNomenclatureMovementOperationFrom;
+			set => SetField(ref _employeeNomenclatureMovementOperationFrom, value);
+		}
+
+		public virtual EmployeeNomenclatureMovementOperation EmployeeNomenclatureMovementOperationTo
+		{
+			get => _employeeNomenclatureMovementOperationTo;
+			set => SetField(ref _employeeNomenclatureMovementOperationTo, value);
+		}
+
+		public override string Title => $"Документ переноса терминала другому водителю №{ Id }";
+	}
+}

--- a/VodovozBusiness/Domain/Documents/DriverTerminalTransfer/DriverTerminalTransferDocumentBase.cs
+++ b/VodovozBusiness/Domain/Documents/DriverTerminalTransfer/DriverTerminalTransferDocumentBase.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using QS.DomainModel.Entity;
+using Vodovoz.Domain.Employees;
+using Vodovoz.Domain.Logistic;
+using Vodovoz.Domain.Operations;
+
+namespace Vodovoz.Domain.Documents.DriverTerminalTransfer
+{
+	public abstract class DriverTerminalTransferDocumentBase : PropertyChangedBase, IDomainObject
+	{
+		private Employee _author;
+		private DateTime _createDate;
+		private Employee _driverFrom;
+		private Employee _driverTo;
+		private RouteList _routeListFrom;
+		private RouteList _routeListTo;
+
+		public virtual int Id { get; set; }
+
+		public virtual Employee Author
+		{
+			get => _author;
+			set => SetField(ref _author, value);
+		}
+
+		public virtual DateTime CreateDate
+		{
+			get => _createDate;
+			set => SetField(ref _createDate, value);
+		}
+
+		public virtual Employee DriverFrom
+		{
+			get => _driverFrom;
+			set => SetField(ref _driverFrom, value);
+		}
+
+		public virtual Employee DriverTo
+		{
+			get => _driverTo;
+			set => SetField(ref _driverTo, value);
+		}
+
+		public virtual RouteList RouteListFrom
+		{
+			get => _routeListFrom;
+			set => SetField(ref _routeListFrom, value);
+		}
+
+		public virtual RouteList RouteListTo
+		{
+			get => _routeListTo;
+			set => SetField(ref _routeListTo, value);
+		}
+
+		public abstract string Title { get; }
+	}
+}

--- a/VodovozBusiness/Domain/Documents/DriverTerminalTransfer/DriverTerminalTransferDocumentType.cs
+++ b/VodovozBusiness/Domain/Documents/DriverTerminalTransfer/DriverTerminalTransferDocumentType.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Vodovoz.Domain.Documents.DriverTerminalTransfer
+{
+	public enum DriverTerminalTransferDocumentType
+	{
+		[Display(Name = "Документ переноса терминала другому водителю")]
+		AnotherDriver,
+		[Display(Name = "Документ переноса терминала для одного водителя")]
+		SelfDriver
+	}
+}

--- a/VodovozBusiness/Domain/Documents/DriverTerminalTransfer/SelfDriverTerminalTransferDocument.cs
+++ b/VodovozBusiness/Domain/Documents/DriverTerminalTransfer/SelfDriverTerminalTransferDocument.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using QS.DomainModel.Entity;
+using QS.DomainModel.Entity.EntityPermissions;
+using QS.HistoryLog;
+using Vodovoz.Domain.Employees;
+using Vodovoz.Domain.Logistic;
+using Vodovoz.Domain.Operations;
+
+namespace Vodovoz.Domain.Documents.DriverTerminalTransfer
+{
+	[Appellative(Gender = GrammaticalGender.Masculine,
+		Nominative = "документ переноса терминала для одного водителя",
+		NominativePlural = "документы переноса терминалов для одного водителя")]
+	[EntityPermission]
+	[HistoryTrace]
+	public class SelfDriverTerminalTransferDocument : DriverTerminalTransferDocumentBase
+	{
+		public override string Title => $"Документ переноса терминала для одного водителя №{ Id }";
+	}
+}

--- a/VodovozBusiness/Domain/Logistic/RouteList.cs
+++ b/VodovozBusiness/Domain/Logistic/RouteList.cs
@@ -1320,8 +1320,11 @@ namespace Vodovoz.Domain.Logistic
 						RouteListTo = foundRouteList,
 					};
 
-					UoW.Save(terminalTransferDocumentForOneDriver);
-					UoW.Commit();
+					using(var localUoW = UnitOfWorkFactory.CreateWithoutRoot())
+					{
+						localUoW.Save(terminalTransferDocumentForOneDriver);
+						localUoW.Commit();
+					}
 
 					ServicesConfig.InteractiveService.ShowMessage(
 						ImportanceLevel.Info, 

--- a/VodovozBusiness/Domain/Logistic/RouteList.cs
+++ b/VodovozBusiness/Domain/Logistic/RouteList.cs
@@ -19,6 +19,8 @@ using Vodovoz.Controllers;
 using Vodovoz.Core.DataService;
 using Vodovoz.Domain.Cash;
 using Vodovoz.Domain.Documents;
+using Vodovoz.Domain.Documents.DriverTerminal;
+using Vodovoz.Domain.Documents.DriverTerminalTransfer;
 using Vodovoz.Domain.Employees;
 using Vodovoz.Domain.Goods;
 using Vodovoz.Domain.Operations;
@@ -744,8 +746,9 @@ namespace Vodovoz.Domain.Logistic
 			foreach(var good in goods) {
 				var loaded = inLoaded.FirstOrDefault(x => x.NomenclatureId == good.NomenclatureId);
 
-				if(good.NomenclatureId == terminalId 
-					&& (loaded?.Amount ?? 0) + terminalsTransferedToThisRL == good.Amount)
+				if(good.NomenclatureId == terminalId
+					&& ((loaded?.Amount ?? 0) + terminalsTransferedToThisRL == good.Amount 
+					    || _routeListRepository.GetSelfDriverTerminalTransferDocument(UoW, Driver, this) != null))
 				{
 					continue;
 				}
@@ -1236,6 +1239,98 @@ namespace Vodovoz.Domain.Logistic
 		public virtual bool PrintAsClosed() =>
 			new[] { RouteListStatus.Delivered, RouteListStatus.MileageCheck, RouteListStatus.OnClosing, RouteListStatus.Closed }
 				.Contains(Status);
+
+		public virtual void CreateSelfDriverTerminalTransferDocument()
+		{
+			if(_routeListRepository.GetLastTerminalDocumentForEmployee(UoW, Driver) is DriverAttachedTerminalGiveoutDocument)
+			{
+				ServicesConfig.InteractiveService.ShowMessage(
+					ImportanceLevel.Warning,
+					$"Терминал привязан к водителю { Driver.GetPersonNameWithInitials() }",
+					"Не удалось перенести терминал");
+
+				return;
+			}
+
+			var foundRouteLists = UoW.Session.QueryOver<RouteList>()
+				.Where(x => x.Driver == this.Driver
+				            && x.Date == this.Date
+				            && x.Status == RouteListStatus.InLoading
+				            && x.Id != this.Id)
+				.List();
+
+			if(foundRouteLists.Count == 0)
+			{
+				ServicesConfig.InteractiveService.ShowMessage(
+					ImportanceLevel.Warning,
+					$"Не найдены подходящие МЛ для переноса терминала из МЛ №{ Id }. Попробуйте перенести терминал вручную.",
+					"Не удалось перенести терминал");
+
+				return;
+			}
+
+			var terminalId = _baseParametersProvider.GetNomenclatureIdForTerminal;
+			var loadedTerminalAmount = _carLoadDocumentRepository.LoadedTerminalAmount(UoW, Id, terminalId);
+			var unloadedTerminalAmount = _carUnloadRepository.UnloadedTerminalAmount(UoW, Id, terminalId);
+
+			if(loadedTerminalAmount - unloadedTerminalAmount <= 0)
+			{
+				ServicesConfig.InteractiveService.ShowMessage(
+					ImportanceLevel.Warning,
+					$"В МЛ №{ Id } отсутствуют погруженные терминалы.");
+
+				return;
+			}
+
+			if(foundRouteLists.Count > 1)
+			{
+				ServicesConfig.InteractiveService.ShowMessage(
+					ImportanceLevel.Warning,
+					$"Для переноса терминала из МЛ № { Id } найдено больше одного МЛ: " +
+						$"{string.Join(", ", foundRouteLists.Select(x => x.Id).ToArray())}.\nПопробуйте перенести терминал вручную.",
+					"Не удалось перенести терминал");
+
+				return;
+			}
+
+			var foundRouteList = foundRouteLists.FirstOrDefault();
+
+			var selfDriverTerminalTransferDocument = _routeListRepository.GetSelfDriverTerminalTransferDocument(UoW, foundRouteList.Driver, foundRouteList);
+
+			if(selfDriverTerminalTransferDocument != null)
+			{
+				ServicesConfig.InteractiveService.ShowMessage(
+					ImportanceLevel.Warning,
+					$"Терминал уже был перенесён в МЛ №{ selfDriverTerminalTransferDocument.RouteListTo.Id }",
+					"Не удалось перенести терминал");
+
+				return;
+			}
+			else
+			{
+				if(ServicesConfig.InteractiveService.Question($"Терминал будет перенесён из МЛ №{ Id } в МЛ №{ foundRouteList.Id }. Продолжить?"))
+				{
+					var terminalTransferDocumentForOneDriver = new SelfDriverTerminalTransferDocument()
+					{
+						Author = _employeeRepository.GetEmployeeForCurrentUser(UoW),
+						CreateDate = DateTime.Now,
+						DriverFrom = foundRouteList.Driver,
+						DriverTo = foundRouteList.Driver,
+						RouteListFrom = this,
+						RouteListTo = foundRouteList,
+					};
+
+					UoW.Save(terminalTransferDocumentForOneDriver);
+					UoW.Commit();
+
+					ServicesConfig.InteractiveService.ShowMessage(
+						ImportanceLevel.Info, 
+						$"Терминал перенесён в МЛ №{ foundRouteList.Id }",
+						"Готово");
+				}
+			}
+		}
+
 
 		#endregion
 
@@ -1999,12 +2094,15 @@ namespace Vodovoz.Domain.Logistic
 			if(Id > 0) {
 				var loadedNomenclatures = _routeListRepository.AllGoodsLoaded(UoW, this);
 				var nomenclaturesToLoad = _routeListRepository.GetGoodsAndEquipsInRL(UoW, this);
-				
+				var hasSelfDriverTerminalTransferDocument = _routeListRepository.GetSelfDriverTerminalTransferDocument(UoW, this.Driver, this) != null;
+
 				foreach(var n in nomenclaturesToLoad) {
-					
-					if(!needTerminalAccounting && n.NomenclatureId == terminalId)
+
+					if(n.NomenclatureId == terminalId && (!needTerminalAccounting || hasSelfDriverTerminalTransferDocument))
+					{
 						continue;
-					
+					}
+
 					var loaded = loadedNomenclatures.FirstOrDefault(x => x.NomenclatureId == n.NomenclatureId);
 					decimal loadedAmount = 0;
 					if(loaded != null)

--- a/VodovozBusiness/EntityRepositories/Logistic/IRouteListRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Logistic/IRouteListRepository.cs
@@ -4,6 +4,7 @@ using NHibernate.Criterion;
 using QS.DomainModel.UoW;
 using Vodovoz.Domain.Documents;
 using Vodovoz.Domain.Documents.DriverTerminal;
+using Vodovoz.Domain.Documents.DriverTerminalTransfer;
 using Vodovoz.Domain.Employees;
 using Vodovoz.Domain.Goods;
 using Vodovoz.Domain.Logistic;
@@ -51,5 +52,6 @@ namespace Vodovoz.EntityRepositories.Logistic
 			Warehouse warehouse = null);
 		DriverAttachedTerminalDocumentBase GetLastTerminalDocumentForEmployee(IUnitOfWork uow, Employee employee);
 		IEnumerable<KeyValuePair<string, int>> GetDeliveryItemsToReturn(IUnitOfWork unitOfWork, int routeListsId);
+		SelfDriverTerminalTransferDocument GetSelfDriverTerminalTransferDocument(IUnitOfWork unitOfWork, Employee driver, RouteList routeList);
 	}
 }

--- a/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
@@ -11,6 +11,7 @@ using Vodovoz.Domain;
 using Vodovoz.Domain.Client;
 using Vodovoz.Domain.Documents;
 using Vodovoz.Domain.Documents.DriverTerminal;
+using Vodovoz.Domain.Documents.DriverTerminalTransfer;
 using Vodovoz.Domain.Employees;
 using Vodovoz.Domain.Goods;
 using Vodovoz.Domain.Logistic;
@@ -416,6 +417,11 @@ namespace Vodovoz.EntityRepositories.Logistic
 				return null;
 			}
 
+			if(GetSelfDriverTerminalTransferDocument(uow, routeList.Driver, routeList) != null)
+			{//если терминал был перенесён на вторую ходку, то не надо его грузить
+				return null;
+			}
+
 			var transferedCount = TerminalTransferedCountToRouteList(uow, routeList);
 
 			var terminalId = _terminalNomenclatureProvider.GetNomenclatureIdForTerminal;
@@ -564,7 +570,7 @@ namespace Vodovoz.EntityRepositories.Logistic
 				throw new ArgumentNullException(nameof(routeList));
 			}
 
-			var termanalTransferDocumentItems = unitOfWork.Session.Query<DriverTerminalTransferDocument>()
+			var termanalTransferDocumentItems = unitOfWork.Session.Query<DriverTerminalTransferDocumentBase>()
 				.Where(dttd => dttd.RouteListTo.Id == routeList.Id
 							|| dttd.RouteListFrom.Id == routeList.Id)
 				.ToList();
@@ -850,6 +856,11 @@ namespace Vodovoz.EntityRepositories.Logistic
 						).WithAlias(() => keyValuePairAlias.Value)
 				).TransformUsing(Transformers.AliasToBean<KeyValuePair<string, int>>()).List<KeyValuePair<string, int>>();
 		}
+
+		public SelfDriverTerminalTransferDocument GetSelfDriverTerminalTransferDocument(IUnitOfWork unitOfWork, Employee driver, RouteList routeList) =>
+			unitOfWork.Session.QueryOver<SelfDriverTerminalTransferDocument>()
+				.Where(d => d.DriverTo == driver && d.RouteListTo == routeList)
+				.SingleOrDefault();
 	}
 
 	#region DTO

--- a/VodovozBusiness/HibernateMapping/Documents/DriverTerminalTransferDocumentBaseMap.cs
+++ b/VodovozBusiness/HibernateMapping/Documents/DriverTerminalTransferDocumentBaseMap.cs
@@ -1,0 +1,50 @@
+﻿using FluentNHibernate.Mapping;
+using Vodovoz.Domain.Documents;
+using Vodovoz.Domain.Documents.DriverTerminalTransfer;
+
+namespace Vodovoz.HibernateMapping.Documents
+{
+	public class DriverTerminalTransferDocumentBaseMap : ClassMap<DriverTerminalTransferDocumentBase>
+	{
+		public DriverTerminalTransferDocumentBaseMap()
+		{
+			Table("driver_terminal_transfer_documents");
+
+			DiscriminateSubClassesOnColumn("type");
+
+			Id(x => x.Id).Column("id").GeneratedBy.Native();
+
+			Map(x => x.CreateDate).Column("create_date");
+
+			References(x => x.Author).Column("author_id");
+
+			References(x => x.RouteListFrom).Column("routelist_from_id");
+			References(x => x.RouteListTo).Column("routelist_to_id");
+
+			References(x => x.DriverFrom).Column("driver_from_id");
+			References(x => x.DriverTo).Column("driver_to_id");
+		}
+
+		public class DriverTerminalTransferDocumentMap : SubclassMap<AnotherDriverTerminalTransferDocument>
+		{
+			public DriverTerminalTransferDocumentMap()
+			{
+				DiscriminatorValue(DriverTerminalTransferDocumentType.AnotherDriver.ToString());
+
+				References(x => x.EmployeeNomenclatureMovementOperationFrom)
+					.Cascade.All().Column("employee_nomenclature_movement_operation_from_id");
+					
+				References(x => x.EmployeeNomenclatureMovementOperationTo)
+					.Cascade.All().Column("employee_nomenclature_movement_operation_to_id");
+			}
+		}
+
+		public class SelfDriverTerminalTransferDocumentMap : SubclassMap<SelfDriverTerminalTransferDocument>
+		{
+			public SelfDriverTerminalTransferDocumentMap()
+			{
+				DiscriminatorValue(DriverTerminalTransferDocumentType.SelfDriver.ToString());
+			}
+		}
+	}
+}

--- a/VodovozBusiness/VodovozBusiness.csproj
+++ b/VodovozBusiness/VodovozBusiness.csproj
@@ -61,7 +61,10 @@
     <Compile Include="Domain\Cash\OrganizationCashTransferDocument.cs" />
     <Compile Include="Domain\Client\CounterpartyFile.cs" />
     <Compile Include="Domain\Complaints\ComplaintObject.cs" />
-    <Compile Include="Domain\Documents\DriverTerminalTransferDocument.cs" />
+    <Compile Include="Domain\Documents\DriverTerminalTransfer\DriverTerminalTransferDocumentType.cs" />
+    <Compile Include="Domain\Documents\DriverTerminalTransfer\SelfDriverTerminalTransferDocument.cs" />
+    <Compile Include="Domain\Documents\DriverTerminalTransfer\DriverTerminalTransferDocumentBase.cs" />
+    <Compile Include="Domain\Documents\DriverTerminalTransfer\AnotherDriverTerminalTransferDocument.cs" />
     <Compile Include="Domain\Documents\DocumentPrintHistory.cs" />
     <Compile Include="Domain\Client\DeliveryPointEstimatedCoordinate.cs" />
     <Compile Include="Domain\Complaints\DriverComplaintReason.cs" />
@@ -266,7 +269,7 @@
     <Compile Include="HibernateMapping\Documents\DeliveryDocumentItemMap.cs" />
     <Compile Include="HibernateMapping\Documents\DeliveryDocumentMap.cs" />
     <Compile Include="HibernateMapping\Documents\DriverNomenclatureTransferItemMap.cs" />
-    <Compile Include="HibernateMapping\Documents\DriverTerminalTransferDocumentMap.cs" />
+    <Compile Include="HibernateMapping\Documents\DriverTerminalTransferDocumentBaseMap.cs" />
     <Compile Include="HibernateMapping\Documents\DriverTerminal\DriverAttachedTerminalDocumentsMap.cs" />
     <Compile Include="HibernateMapping\FinancialDistrictMap.cs" />
     <Compile Include="HibernateMapping\FinancialDistrictsSetMap.cs" />


### PR DESCRIPTION
Доработка позволяет грузить терминал водителю с его старого МЛ на его новый, когда один и тот же водитель делает 2 ходки утром и вечером, и вечером он попросит тот же терминал.

В "Журнале МЛ" и в "Работа кассы с МЛ" добавлен пункт "Перенести терминал на 2-ю ходку". По нажатии происходит поиск второго МЛ на ту же дату, с тем же водителем и только со статусом "На погрузке". Если не нашел или нашел больше одного, то выдаётся сообщение с причиной и просьбой перенести вручную. Также добавлены в проверку ситуации, когда терминал может быть привязанным к водителю в карточке или терминала может не быть в первом МЛ.
Если нашли, то переносим терминал через новый документ.

Выделен базовый класс из DriverTerminalTransferDocument. Одна реализация текущая, другая только для переноса терминалов из одного МЛ в другой для одного водителя (без операций).

Доработана и проверена логика смены водителя, которому перенесли терминал, логика закрытия старого МЛ, нового МЛ, а также их погрузки и разгрузки.

При формировании документа разгрузки ищутся и отображаются все переносы между МЛ (Которые в итоге перенесли терминал в текущий МЛ).