### PR TITLE
2664 Исключение из валидации проверки текущего МЛ в других МЛ

### DIFF
--- a/VodovozBusiness/Domain/Logistic/RouteList.cs
+++ b/VodovozBusiness/Domain/Logistic/RouteList.cs
@@ -1382,8 +1382,15 @@ namespace Vodovoz.Domain.Logistic
 				IRouteListItemRepository rliRepository = (IRouteListItemRepository)validationContext.Items[nameof(IRouteListItemRepository)];
 				foreach(var address in Addresses) {
 					if(rliRepository.AnotherRouteListItemForOrderExist(UoW, address))
-						yield return new ValidationResult($"Один из адрессов, находится в другом МЛ");
-					
+					{
+						yield return new ValidationResult($"Адрес {address.Order.Id} находится в другом МЛ");
+					}
+
+					if(rliRepository.CurrentRouteListHasOrderDuplicate(UoW, address, Addresses.Select(x => x.Id).ToArray()))
+					{
+						yield return new ValidationResult($"Адрес { address.Order.Id } дублируется в текущем МЛ");
+					}
+
 					foreach (var result in address.Validate(new ValidationContext(address)))
 						yield return result;
 				}

--- a/VodovozBusiness/EntityRepositories/Logistic/IRouteListItemRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Logistic/IRouteListItemRepository.cs
@@ -14,6 +14,7 @@ namespace Vodovoz.EntityRepositories.Logistic
 		bool HasRouteListItemsForOrder(IUnitOfWork uow, Order order);
 		bool WasOrderInAnyRouteList(IUnitOfWork uow, Order order);
 		bool AnotherRouteListItemForOrderExist(IUnitOfWork uow, RouteListItem routeListItem);
+		bool CurrentRouteListHasOrderDuplicate(IUnitOfWork uow, RouteListItem routeListItem, int[] actualRouteListItemIds);
 		RouteListItem GetRouteListItemById(IUnitOfWork uow, int routeListAddressId);
 	}
 }

--- a/VodovozBusiness/EntityRepositories/Logistic/RouteListItemRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Logistic/RouteListItemRepository.cs
@@ -74,8 +74,21 @@ namespace Vodovoz.EntityRepositories.Logistic
 					.And(x => x.Id != routeListItem.Id)
 					.And(x => x.Status != RouteListItemStatus.Transfered)
 					.And(!Restrictions.In(Projections.Property<RouteListItem>(x => x.Status), undeliveryStatus))
+					.And(x => x.RouteList != routeListItem.RouteList)
 					.Take(1).List().FirstOrDefault();
 			return anotherRouteListItem != null;
+		}
+
+		public bool CurrentRouteListHasOrderDuplicate(IUnitOfWork uow, RouteListItem routeListItem, int [] actualRouteListItemIds)
+		{
+			var currentRouteListOrderDuplicate = uow.Session.QueryOver<RouteListItem>()
+				.Where(x => x.Order.Id == routeListItem.Order.Id)
+				.And(x => x.Id != routeListItem.Id)
+				.And(x => x.RouteList == routeListItem.RouteList)
+				.And(Restrictions.In(Projections.Property<RouteListItem>(x => x.Id), actualRouteListItemIds))
+				.Take(1).List().FirstOrDefault();
+
+			return currentRouteListOrderDuplicate != null;
 		}
 
         public RouteListItem GetRouteListItemById(IUnitOfWork uow, int routeListAddressId)


### PR DESCRIPTION
Каким-то образом возможно сформировать дубль адреса. И эту ситуацию не получается исправить в диалоге создания. 

Чтобы такую ситуацию можно было исправить в диалоге создания МЛ была исправлена проверка на нахождение адреса в **другом** МЛ (в методе исключён **текущий** МЛ из проверки).

В репозиторий добавлена проверка дубликатов в текущем МЛ. В метод передаётся актуальный список адресов (т.к. его, возможно, ещё не успели сохранить после удаления дубликата).