### PR TITLE
3795 Исправление переноса адресов в МЛ

### DIFF
--- a/Vodovoz/Dialogs/Logistic/RouteListAddressesTransferringDlg.cs
+++ b/Vodovoz/Dialogs/Logistic/RouteListAddressesTransferringDlg.cs
@@ -203,7 +203,7 @@ namespace Vodovoz
 			if(isRightPanel)
 			{
 				config.AddColumn("Нужна загрузка").AddToggleRenderer(node => node.NeedToReload)
-					  .AddSetter((c, n) => c.Sensitive = n.WasTransfered);
+					.Editing(false);
 			}
 			else
 			{
@@ -411,7 +411,7 @@ namespace Vodovoz
 
 				if(routeListTo.ClosingFilled)
 				{
-					newItem.FirstFillClosing(UoW, _wageParameterService);
+					newItem.FirstFillClosing(_wageParameterService);
 				}
 
 				UoW.Save(item);
@@ -491,29 +491,16 @@ namespace Vodovoz
 
 				if(pastPlace != null)
 				{
-					previousRouteList.SetAddressStatusWithoutOrderChange(pastPlace.Id, address.Status);
-					pastPlace.DriverBottlesReturned = address.DriverBottlesReturned;
-					previousRouteList.TransferAddressTo(pastPlace.Id, null);
-
-					if(pastPlace.RouteList.ClosingFilled)
-					{
-						pastPlace.FirstFillClosing(UoW, _wageParameterService);
-					}
-
+					previousRouteList.RevertTransferAddress(_wageParameterService, pastPlace, address);
 					UpdateTranferDocuments(pastPlace.RouteList, address.RouteList);
+					pastPlace.RecalculateTotalCash();
 					UoW.Save(pastPlace);
-					UoW.Save(previousRouteList);
 				}
 
 				address.RouteList.ObservableAddresses.Remove(address);
 				UoW.Save(address.RouteList);
 			}
-
-			foreach (var routeListItem in toRevert)
-			{
-				routeListItem.RecalculateTotalCash();
-			}
-
+			
 			UoW.Commit();
 			UpdateNodes();
 		}
@@ -688,20 +675,8 @@ namespace Vodovoz
 		public string Address => RouteListItem.Order.DeliveryPoint?.ShortAddress ?? "Нет адреса";
 		public RouteListItemStatus Status => RouteListItem.Status;
 
-		public bool NeedToReload
-		{
-			get => RouteListItem.NeedToReload;
-			set
-			{
-				if(RouteListItem.WasTransfered)
-				{
-					RouteListItem.NeedToReload = value;
-					RouteListItem.RouteList.UoW.Save(RouteListItem);
-					RouteListItem.RouteList.UoW.Commit();
-				}
-			}
-		}
-
+		public bool NeedToReload => RouteListItem.NeedToReload;
+		
 		bool _leftNeedToReload;
 		public bool LeftNeedToReload
 		{

--- a/Vodovoz/ViewWidgets/Logistics/OrderReturnsView.cs
+++ b/Vodovoz/ViewWidgets/Logistics/OrderReturnsView.cs
@@ -424,7 +424,7 @@ namespace Vodovoz
 		{
 			_routeListItem.RouteList.ChangeAddressStatusAndCreateTask(UoW, _routeListItem.Id, RouteListItemStatus.Completed, CallTaskWorker);
 			_routeListItem.RestoreOrder();
-			_routeListItem.FirstFillClosing(UoW, _wageParameterService);
+			_routeListItem.FirstFillClosing(_wageParameterService);
 			UpdateListsSentivity();
 			UpdateButtonsState();
 		}

--- a/VodovozBusiness/Domain/Logistic/RouteList.cs
+++ b/VodovozBusiness/Domain/Logistic/RouteList.cs
@@ -1193,6 +1193,10 @@ namespace Vodovoz.Domain.Logistic
 			UpdateStatus();
 		}
 
+		public virtual void RevertTransferAddress(
+			WageParameterService wageParameterService, RouteListItem targetAddress, RouteListItem revertedAddress) =>
+				targetAddress.RevertTransferAddress(wageParameterService, revertedAddress);
+
 		private void UpdateClosedInformation()
 		{
 			if(Status == RouteListStatus.Closed)
@@ -1439,7 +1443,7 @@ namespace Vodovoz.Domain.Logistic
 				PerformanceHelper.StartPointsGroup($"Заказ {routeListItem.Order.Id}");
 
 				logger.Debug("Количество элементов в заказе {0}", routeListItem.Order.OrderItems.Count);
-				routeListItem.FirstFillClosing(UoW, wageParameterService);
+				routeListItem.FirstFillClosing(wageParameterService);
 				PerformanceHelper.EndPointsGroup();
 			}
 

--- a/VodovozBusiness/Domain/Logistic/RouteListItem.cs
+++ b/VodovozBusiness/Domain/Logistic/RouteListItem.cs
@@ -14,6 +14,7 @@ using Vodovoz.Domain.Orders;
 using Vodovoz.Domain.WageCalculation;
 using Vodovoz.Domain.WageCalculation.CalculationServices.RouteList;
 using Vodovoz.EntityRepositories.Logistic;
+using Vodovoz.Services;
 using Vodovoz.Tools.CallTasks;
 using Vodovoz.Tools.Logistic;
 
@@ -571,6 +572,18 @@ namespace Vodovoz.Domain.Logistic
 			TransferedTo = targetAddress;
 			SetStatusWithoutOrderChange(RouteListItemStatus.Transfered);
 		}
+		
+		protected internal virtual void RevertTransferAddress(WageParameterService wageParameterService, RouteListItem revertedAddress)
+		{
+			SetStatusWithoutOrderChange(revertedAddress.Status);
+			TransferedTo = null;
+			DriverBottlesReturned = revertedAddress.DriverBottlesReturned;
+			
+			if(RouteList.ClosingFilled)
+			{
+				FirstFillClosing(wageParameterService);
+			}
+		}
 
 		public virtual void RecalculateTotalCash() => TotalCash = CalculateTotalCash();
 
@@ -605,8 +618,7 @@ namespace Vodovoz.Domain.Logistic
 		/// Функция вызывается при переходе адреса в закрытие.
 		/// Если адрес в пути, при закрытии МЛ он считается автоматически доставленным.
 		/// </summary>
-		/// <param name="uow">Uow.</param>
-		public virtual void FirstFillClosing(IUnitOfWork uow, WageParameterService wageParameterService)
+		public virtual void FirstFillClosing(WageParameterService wageParameterService)
 		{
 			//В этом месте изменяем статус для подстраховки.
 			if(Status == RouteListItemStatus.EnRoute)


### PR DESCRIPTION
Исправил ошибку с некорректным возвратом адреса при переносе в исходный МЛ

- сделал колонку Нужна загрузка нередактируемой в правой панели;
- удалил неиспользуемый параметр из метода FirstFillClosing;