### PR TITLE
Фикс расчета минут опозданий 

### DIFF
--- a/Vodovoz/Reports/Logistic/AnalyticsForUndelivery.rdl
+++ b/Vodovoz/Reports/Logistic/AnalyticsForUndelivery.rdl
@@ -1803,44 +1803,45 @@ group by case
       </Fields>
     </DataSet>
     <DataSet Name="deliveries_late_Set">
-      <Query>
+      <Query >
         <DataSourceName>DS1</DataSourceName>
-        <CommandText>SELECT
-    districts.geographic_group_id,
-    IFNULL(orders.time_delivered,
-           route_list_addresses.status_last_update) AS Addresses,
-    TIMEDIFF(TIME(IFNULL(orders.time_delivered,
-                         route_list_addresses.status_last_update)),
-             delivery_schedule.to_time) AS delay,
-    TIMESTAMPDIFF(MINUTE,delivery_schedule.to_time,TIME(IFNULL(orders.time_delivered,
-                                                               route_list_addresses.status_last_update))
-        ) AS Minutes
-FROM
-    route_lists
-        LEFT JOIN employees ON employees.id = route_lists.driver_id
-        LEFT JOIN route_list_addresses ON route_list_addresses.route_list_id = route_lists.id
-        LEFT JOIN orders ON orders.id = route_list_addresses.order_id
-        LEFT JOIN counterparty ON counterparty.id = orders.client_id
-        LEFT JOIN delivery_points ON delivery_points.id = orders.delivery_point_id
-        LEFT JOIN delivery_schedule ON delivery_schedule.id = orders.delivery_schedule_id
-        LEFT JOIN late_arrival_reasons lar on route_list_addresses.late_arrival_reason_id = lar.id
-        LEFT JOIN employees lo_comment_author ON lo_comment_author.id = route_list_addresses.comment_for_fine_author_id
-        LEFT OUTER JOIN fines_to_route_list_addresses fine_route_list_adrs on route_list_addresses.id = fine_route_list_adrs.route_list_address_id
-        LEFT OUTER JOIN fines fine on fine_route_list_adrs.fine_id = fine.id
-        LEFT JOIN districts ON delivery_points.district_id = districts.id
-WHERE
-        route_lists.`date` = @first_date
-  AND route_list_addresses.status = 'Completed'
-  AND employees.visiting_master = 0
-GROUP BY route_list_addresses.id
-HAVING delay &gt; 0</CommandText>
+        <CommandText>select Result.Addresses as Addresses, CAST(Result.Minutes AS INT) as Minutes from (
+                  SELECT
+                      IFNULL(orders.time_delivered,
+                             route_list_addresses.status_last_update) AS Addresses,
+                      TIMEDIFF(TIME(IFNULL(orders.time_delivered,
+                                           route_list_addresses.status_last_update)),
+                               delivery_schedule.to_time) AS delay,
+                      (TIMESTAMPDIFF(SECOND,delivery_schedule.to_time,TIME(IFNULL(orders.time_delivered,
+                                                                                  route_list_addresses.status_last_update))
+                           )/60) AS Minutes
+                  FROM
+                      route_lists
+                          LEFT JOIN employees ON employees.id = route_lists.driver_id
+                          LEFT JOIN route_list_addresses ON route_list_addresses.route_list_id = route_lists.id
+                          LEFT JOIN orders ON orders.id = route_list_addresses.order_id
+                          LEFT JOIN counterparty ON counterparty.id = orders.client_id
+                          LEFT JOIN delivery_points ON delivery_points.id = orders.delivery_point_id
+                          LEFT JOIN delivery_schedule ON delivery_schedule.id = orders.delivery_schedule_id
+                          LEFT JOIN late_arrival_reasons lar on route_list_addresses.late_arrival_reason_id = lar.id
+                          LEFT JOIN employees lo_comment_author ON lo_comment_author.id = route_list_addresses.comment_for_fine_author_id
+                          LEFT OUTER JOIN fines_to_route_list_addresses fine_route_list_adrs on route_list_addresses.id = fine_route_list_adrs.route_list_address_id
+                          LEFT OUTER JOIN fines fine on fine_route_list_adrs.fine_id = fine.id
+                          LEFT JOIN districts ON delivery_points.district_id = districts.id
+                  WHERE
+                          route_lists.`date` = @first_date
+                    AND route_list_addresses.status = 'Completed'
+                    AND employees.visiting_master = 0
+                  GROUP BY route_list_addresses.id
+                  HAVING delay &gt; 0
+                  ) as Result</CommandText>
         <QueryParameters>
           <QueryParameter Name="first_date">
             <Value>=Parameters!first_date</Value>
           </QueryParameter>
         </QueryParameters>
       </Query>
-      <Fields>
+      <Fields >
         <Field Name="Addresses">
           <DataField>Addresses</DataField>
           <TypeName>System.DateTime</TypeName>
@@ -1967,44 +1968,45 @@ FROM
       </Fields>
     </DataSet>
     <DataSet Name="deliveries_late_Set_2">
-      <Query>
+      <Query >
         <DataSourceName>DS1</DataSourceName>
-        <CommandText>SELECT
-    districts.geographic_group_id,
-    IFNULL(orders.time_delivered,
-           route_list_addresses.status_last_update) AS Addresses,
-    TIMEDIFF(TIME(IFNULL(orders.time_delivered,
-                         route_list_addresses.status_last_update)),
-             delivery_schedule.to_time) AS delay,
-    TIMESTAMPDIFF(MINUTE,delivery_schedule.to_time,TIME(IFNULL(orders.time_delivered,
-                                                               route_list_addresses.status_last_update))
-        ) AS Minutes
-FROM
-    route_lists
-        LEFT JOIN employees ON employees.id = route_lists.driver_id
-        LEFT JOIN route_list_addresses ON route_list_addresses.route_list_id = route_lists.id
-        LEFT JOIN orders ON orders.id = route_list_addresses.order_id
-        LEFT JOIN counterparty ON counterparty.id = orders.client_id
-        LEFT JOIN delivery_points ON delivery_points.id = orders.delivery_point_id
-        LEFT JOIN delivery_schedule ON delivery_schedule.id = orders.delivery_schedule_id
-        LEFT JOIN late_arrival_reasons lar on route_list_addresses.late_arrival_reason_id = lar.id
-        LEFT JOIN employees lo_comment_author ON lo_comment_author.id = route_list_addresses.comment_for_fine_author_id
-        LEFT OUTER JOIN fines_to_route_list_addresses fine_route_list_adrs on route_list_addresses.id = fine_route_list_adrs.route_list_address_id
-        LEFT OUTER JOIN fines fine on fine_route_list_adrs.fine_id = fine.id
-        LEFT JOIN districts ON delivery_points.district_id = districts.id
-WHERE
-        route_lists.`date` = @second_date
-  AND route_list_addresses.status = 'Completed'
-  AND employees.visiting_master = 0
-GROUP BY route_list_addresses.id
-HAVING delay &gt; 0</CommandText>
+        <CommandText>select Result.Addresses as Addresses, CAST(Result.Minutes AS INT) as Minutes from (
+                  SELECT
+                      IFNULL(orders.time_delivered,
+                             route_list_addresses.status_last_update) AS Addresses,
+                      TIMEDIFF(TIME(IFNULL(orders.time_delivered,
+                                           route_list_addresses.status_last_update)),
+                               delivery_schedule.to_time) AS delay,
+                      (TIMESTAMPDIFF(SECOND,delivery_schedule.to_time,TIME(IFNULL(orders.time_delivered,
+                                                                                  route_list_addresses.status_last_update))
+                           )/60) AS Minutes
+                  FROM
+                      route_lists
+                          LEFT JOIN employees ON employees.id = route_lists.driver_id
+                          LEFT JOIN route_list_addresses ON route_list_addresses.route_list_id = route_lists.id
+                          LEFT JOIN orders ON orders.id = route_list_addresses.order_id
+                          LEFT JOIN counterparty ON counterparty.id = orders.client_id
+                          LEFT JOIN delivery_points ON delivery_points.id = orders.delivery_point_id
+                          LEFT JOIN delivery_schedule ON delivery_schedule.id = orders.delivery_schedule_id
+                          LEFT JOIN late_arrival_reasons lar on route_list_addresses.late_arrival_reason_id = lar.id
+                          LEFT JOIN employees lo_comment_author ON lo_comment_author.id = route_list_addresses.comment_for_fine_author_id
+                          LEFT OUTER JOIN fines_to_route_list_addresses fine_route_list_adrs on route_list_addresses.id = fine_route_list_adrs.route_list_address_id
+                          LEFT OUTER JOIN fines fine on fine_route_list_adrs.fine_id = fine.id
+                          LEFT JOIN districts ON delivery_points.district_id = districts.id
+                  WHERE
+                          route_lists.`date` = @second_date
+                    AND route_list_addresses.status = 'Completed'
+                    AND employees.visiting_master = 0
+                  GROUP BY route_list_addresses.id
+                  HAVING delay &gt; 0
+                  ) as Result</CommandText>
         <QueryParameters>
           <QueryParameter Name="second_date">
             <Value>=Parameters!second_date</Value>
           </QueryParameter>
         </QueryParameters>
       </Query>
-      <Fields>
+      <Fields >
         <Field Name="Addresses">
           <DataField>Addresses</DataField>
           <TypeName>System.DateTime</TypeName>
@@ -2298,11 +2300,11 @@ union (
       </Fields>
     </DataSet>
     <DataSet Name="geopart_divided">
-      <Query>
+      <Query >
         <DataSourceName>DS1</DataSourceName>
         <CommandText>select
        concat('Адреса ', g.name, ' ', count(a.delivered_time)) as Addresses,
-       concat('Минуты ',g.name, ' ', sum(a.delay2)) as Minutes
+       concat('Минуты ',g.name, ' ', cast(sum(a.delay2)as int)) as Minutes
 from
 (SELECT 
        districts.geographic_group_id,
@@ -2311,9 +2313,9 @@ from
     TIMEDIFF(TIME(IFNULL(orders.time_delivered,
                          route_list_addresses.status_last_update)),
              delivery_schedule.to_time) AS delay,
-       TIMESTAMPDIFF(MINUTE,delivery_schedule.to_time,TIME(IFNULL(orders.time_delivered,
+       (TIMESTAMPDIFF(SECOND,delivery_schedule.to_time,TIME(IFNULL(orders.time_delivered,
                             route_list_addresses.status_last_update))
-                ) AS delay2
+                )/60) AS delay2
 FROM
     route_lists
         LEFT JOIN employees ON employees.id = route_lists.driver_id
@@ -2345,7 +2347,7 @@ group by a.geographic_group_id</CommandText>
           </QueryParameter>
         </QueryParameters>
       </Query>
-      <Fields>
+      <Fields >
         <Field Name="Addresses">
           <DataField>Addresses</DataField>
           <TypeName>System.String</TypeName>
@@ -2357,11 +2359,11 @@ group by a.geographic_group_id</CommandText>
       </Fields>
     </DataSet>
     <DataSet Name="geopart_divided2">
-      <Query>
+      <Query >
         <DataSourceName>DS1</DataSourceName>
         <CommandText>select
        concat('Адреса ', g.name, ' ', count(a.delivered_time)) as Addresses,
-       concat('Минуты ',g.name, ' ', sum(a.delay2)) as Minutes
+       concat('Минуты ',g.name, ' ', cast(sum(a.delay2)as int)) as Minutes
 from
 (SELECT 
        districts.geographic_group_id,
@@ -2370,9 +2372,9 @@ from
     TIMEDIFF(TIME(IFNULL(orders.time_delivered,
                          route_list_addresses.status_last_update)),
              delivery_schedule.to_time) AS delay,
-       TIMESTAMPDIFF(MINUTE,delivery_schedule.to_time,TIME(IFNULL(orders.time_delivered,
+       (TIMESTAMPDIFF(SECOND,delivery_schedule.to_time,TIME(IFNULL(orders.time_delivered,
                             route_list_addresses.status_last_update))
-                ) AS delay2
+                )/60) AS delay2
 FROM
     route_lists
         LEFT JOIN employees ON employees.id = route_lists.driver_id
@@ -2404,7 +2406,7 @@ group by a.geographic_group_id</CommandText>
           </QueryParameter>
         </QueryParameters>
       </Query>
-      <Fields>
+      <Fields >
         <Field Name="Addresses">
           <DataField>Addresses</DataField>
           <TypeName>System.String</TypeName>


### PR DESCRIPTION
В отчете по аналитике недовозов в запросам по количеству опозданий на адреса и минуты сделал Timestampdiff через секунды, раньше секунды отбрасывались и итоговые значение расходились