### PR TITLE
Хотфикс 3805: Аванс для новых водителей на своем авто в определённый диапазон дней

### DIFF
--- a/Vodovoz/Dialogs/Logistic/RouteListClosingDlg.cs
+++ b/Vodovoz/Dialogs/Logistic/RouteListClosingDlg.cs
@@ -820,8 +820,8 @@ namespace Vodovoz
 			}
 
 			INewDriverAdvanceParametersProvider newDriverAdvanceParametersProvider = new NewDriverAdvanceParametersProvider(_parametersProvider);
-			NewDriverAdvanceModel newDriverAdvanceModel = new NewDriverAdvanceModel(newDriverAdvanceParametersProvider, Entity);
-			if(newDriverAdvanceModel.NeedNewDriverAdvance(UoW) == true)
+			NewDriverAdvanceModel newDriverAdvanceModel = new NewDriverAdvanceModel(newDriverAdvanceParametersProvider, _routeListRepository, Entity);
+			if(newDriverAdvanceModel.NeedNewDriverAdvance(UoW))
 			{
 				if(newDriverAdvanceModel.UnclosedRouteLists(UoW).Any()
 				   && !MessageDialogHelper.RunQuestionDialog(

--- a/VodovozBusiness/EntityRepositories/Cash/CashRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Cash/CashRepository.cs
@@ -180,6 +180,44 @@ namespace Vodovoz.EntityRepositories.Cash
 				.Select(Projections.Sum<CashTransferOperation>(o => o.TransferedSum))
 				.SingleOrDefault<decimal>();
 		}
+
+		public decimal GetIncomeSumByRouteListId(IUnitOfWork uow, int routeListId, IncomeType[] includedIncomeTypes = null, IncomeType[] excludedIncomeTypes = null)
+		{
+			var query = uow.Session.QueryOver<Income>()
+				.Where(inc => inc.RouteListClosing.Id == routeListId)
+				.Select(Projections.Sum<Income>(inc => inc.Money));
+
+			if(includedIncomeTypes != null)
+			{
+				query.Where(inc => inc.IsIn(includedIncomeTypes));
+			}
+
+			if(excludedIncomeTypes != null)
+			{
+				query.Where(inc => !inc.IsIn(excludedIncomeTypes));
+			}
+
+			return query.SingleOrDefault<decimal>();
+		}
+
+		public decimal GetExpenseSumByRouteListId(IUnitOfWork uow, int routeListId, ExpenseType[] includedExpenseTypes = null, ExpenseType[] excludedExpenseTypes = null)
+		{
+			var query = uow.Session.QueryOver<Expense>()
+				.Where(exp => exp.RouteListClosing.Id == routeListId)
+				.Select(Projections.Sum<Expense>(exp => exp.Money));
+
+			if(includedExpenseTypes != null)
+			{
+				query.Where(exp => exp.TypeOperation.IsIn(includedExpenseTypes));
+			}
+
+			if(excludedExpenseTypes != null)
+			{
+				query.Where(exp => !exp.TypeOperation.IsIn(excludedExpenseTypes));
+			}
+
+			return query.SingleOrDefault<decimal>();
+		}
 	}
 }
 

--- a/VodovozBusiness/EntityRepositories/Cash/ICashRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Cash/ICashRepository.cs
@@ -24,5 +24,7 @@ namespace Vodovoz.EntityRepositories.Cash
 		decimal GetIncomePaidSumForOrder(IUnitOfWork uow, int orderId, int? excludedIncomeDoc = null);
 		bool OrderHasIncome(IUnitOfWork uow, int orderId);
 		IList<OperationNode> GetCashBalanceForOrganizations(IUnitOfWork uow);
+		decimal GetIncomeSumByRouteListId(IUnitOfWork uow, int routeListId, IncomeType[] includedIncomeTypes = null, IncomeType[] excludedIncomeTypes = null);
+		decimal GetExpenseSumByRouteListId(IUnitOfWork uow, int routeListId, ExpenseType[] includedExpenseTypes = null, ExpenseType[] excludedExpenseTypes = null);
 	}
 }

--- a/VodovozBusiness/EntityRepositories/Logistic/IRouteListRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Logistic/IRouteListRepository.cs
@@ -53,5 +53,8 @@ namespace Vodovoz.EntityRepositories.Logistic
 		DriverAttachedTerminalDocumentBase GetLastTerminalDocumentForEmployee(IUnitOfWork uow, Employee employee);
 		IEnumerable<KeyValuePair<string, int>> GetDeliveryItemsToReturn(IUnitOfWork unitOfWork, int routeListsId);
 		SelfDriverTerminalTransferDocument GetSelfDriverTerminalTransferDocument(IUnitOfWork unitOfWork, Employee driver, RouteList routeList);
+		IList<NewDriverAdvanceRouteListNode> GetOldUnclosedRouteLists(IUnitOfWork uow, DateTime routeListDate, int driverId);
+		bool HasEmployeeAdvance(IUnitOfWork uow, int routeListId, int driverId);
+		DateTime GetDateByDriverWorkingDayNumber(IUnitOfWork uow, int driverId, int dayNumber, CarTypeOfUse? carTypeOfUse = null);
 	}
 }

--- a/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
@@ -8,6 +8,7 @@ using NHibernate.Transform;
 using QS.DomainModel.Entity;
 using QS.DomainModel.UoW;
 using Vodovoz.Domain;
+using Vodovoz.Domain.Cash;
 using Vodovoz.Domain.Client;
 using Vodovoz.Domain.Documents;
 using Vodovoz.Domain.Documents.DriverTerminal;
@@ -882,6 +883,53 @@ namespace Vodovoz.EntityRepositories.Logistic
 			unitOfWork.Session.QueryOver<SelfDriverTerminalTransferDocument>()
 				.Where(d => d.DriverTo == driver && d.RouteListTo == routeList)
 				.SingleOrDefault();
+
+		public IList<NewDriverAdvanceRouteListNode> GetOldUnclosedRouteLists(IUnitOfWork uow, DateTime routeListDate, int driverId)
+		{
+			NewDriverAdvanceRouteListNode resultAlias = null;
+
+			var unclosedRouteLists = uow.Session.QueryOver<RouteList>()
+				.Where(x => x.Date < routeListDate)
+				.And(x => x.Status != RouteListStatus.Closed)
+				.And(x => x.Driver.Id == driverId)
+				.SelectList(list => list
+					.Select(x => x.Id).WithAlias(() => resultAlias.Id)
+					.Select(x => x.Date).WithAlias(() => resultAlias.Date)
+				)
+				.TransformUsing(Transformers.AliasToBean<NewDriverAdvanceRouteListNode>())
+				.List<NewDriverAdvanceRouteListNode>();
+
+			return unclosedRouteLists;
+		}
+
+		public bool HasEmployeeAdvance(IUnitOfWork uow, int routeListId, int driverId) =>
+			uow.Session.QueryOver<Expense>()
+				.Where(x => x.RouteListClosing.Id == routeListId)
+				.And(x => x.Employee.Id == driverId)
+				.And(x => x.TypeOperation == ExpenseType.EmployeeAdvance)
+				.RowCount() > 0;
+
+		public DateTime GetDateByDriverWorkingDayNumber(IUnitOfWork uow, int driverId, int dayNumber, CarTypeOfUse? carTypeOfUse = null)
+		{
+			Employee employeeAlias = null;
+
+			var query = uow.Session.QueryOver<RouteList>()
+				.JoinAlias(x => x.Driver, () => employeeAlias)
+				.Where(x => x.Driver.Id == driverId);
+
+			if(carTypeOfUse != null)
+			{
+				query.Where(() => employeeAlias.DriverOf == carTypeOfUse);
+			}
+
+			return query
+				.SelectList(list => list
+					.SelectGroup(x => x.Date))
+				.OrderBy(x => x.Date).Asc
+				.Skip(dayNumber - 1)
+				.Take(1)
+				.SingleOrDefault<DateTime>();
+		}
 	}
 
 	#region DTO
@@ -933,6 +981,12 @@ namespace Vodovoz.EntityRepositories.Logistic
 		public OwnTypes OwnType { get; set; }
 		public decimal? ExpireDatePercent { get; set; } = null;
 		public decimal Amount { get; set; }
+	}
+
+	public class NewDriverAdvanceRouteListNode
+	{
+		public int Id { get; set; }
+		public DateTime Date { get; set; }
 	}
 
 	#endregion

--- a/VodovozBusiness/Models/NewDriverAdvanceModel.cs
+++ b/VodovozBusiness/Models/NewDriverAdvanceModel.cs
@@ -1,0 +1,112 @@
+﻿using NHibernate.Transform;
+using QS.DomainModel.UoW;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentNHibernate.Conventions;
+using Vodovoz.Domain.Cash;
+using Vodovoz.Domain.Employees;
+using Vodovoz.Domain.Logistic;
+using Vodovoz.EntityRepositories.Cash;
+using Vodovoz.Parameters;
+
+namespace Vodovoz.Models
+{
+	public class NewDriverAdvanceModel
+	{
+		private readonly INewDriverAdvanceParametersProvider _newDriverAdvanceParametersProvider;
+		private readonly RouteList _routeList;
+
+		public NewDriverAdvanceModel(INewDriverAdvanceParametersProvider newDriverAdvanceParametersProvider, RouteList routeList)
+		{
+			_newDriverAdvanceParametersProvider = newDriverAdvanceParametersProvider ?? throw new ArgumentNullException(nameof(newDriverAdvanceParametersProvider));
+			_routeList = routeList ?? throw new ArgumentNullException(nameof(routeList));
+		}
+
+		public IList<NewDriverAdvanceRouteListNode> UnclosedRouteLists(IUnitOfWork uow)
+		{
+			NewDriverAdvanceRouteListNode resultAlias = null;
+
+			var unclosedRouteLists = uow.Session.QueryOver<RouteList>()
+				.Where(x => x.Date < _routeList.Date)
+				.And(x => x.Status != RouteListStatus.Closed)
+				.And(x => x.Driver.Id == _routeList.Driver.Id)
+				.SelectList(list => list
+					.Select(x => x.Id).WithAlias(() => resultAlias.Id)
+					.Select(x => x.Date).WithAlias(() => resultAlias.Date)
+				)
+				.TransformUsing(Transformers.AliasToBean<NewDriverAdvanceRouteListNode>())
+				.List<NewDriverAdvanceRouteListNode>();
+
+			return unclosedRouteLists;
+		}
+
+		public bool NeedNewDriverAdvance(IUnitOfWork uow)
+		{
+			var hasAdvance = uow.Session.QueryOver<Expense>()
+				.Where(x => x.RouteListClosing.Id == _routeList.Id)
+				.And(x => x.Employee.Id == _routeList.Driver.Id)
+				.And(x=> x.TypeOperation == ExpenseType.EmployeeAdvance)
+				.RowCount() > 0;
+
+			if(hasAdvance)
+			{
+				return false;
+			}
+
+			Employee employeeAlias = null;
+
+			var firstAdvanceDate = uow.Session.QueryOver<RouteList>()
+				.JoinAlias(x => x.Driver, () => employeeAlias)
+				.Where(x => x.Driver.Id == _routeList.Driver.Id)
+				.And(() => employeeAlias.DriverOf == CarTypeOfUse.DriverCar)
+				.SelectList(list => list
+					.SelectGroup(x => x.Date))
+				.OrderBy(x => x.Date).Asc
+				.Skip(_newDriverAdvanceParametersProvider.NewDriverAdvanceFirstDay - 1)
+				.Take(1)
+				.FutureValue<DateTime>();
+
+			var lastAdvanceDate = uow.Session.QueryOver<RouteList>()
+				.JoinAlias(x => x.Driver, () => employeeAlias)
+				.Where(x => x.Driver.Id == _routeList.Driver.Id)
+				.And(() => employeeAlias.DriverOf == CarTypeOfUse.DriverCar)
+				.SelectList(list => list
+					.SelectGroup(x => x.Date))
+				.OrderBy(x => x.Date).Asc
+				.Skip(_newDriverAdvanceParametersProvider.NewDriverAdvanceLastDay - 1)
+				.Take(1)
+				.FutureValue<DateTime>();
+
+			var needNewDriverAdvance = (firstAdvanceDate.Value <= _routeList.Date)
+									&& (_routeList.Date <= lastAdvanceDate.Value);
+
+			return needNewDriverAdvance;
+		}
+
+		public void CreateNewDriverAdvance(IUnitOfWork uow, ICategoryRepository categoryRepository, decimal cashInput)
+		{
+			Expense cashExpense = null;
+
+			_routeList.EmployeeAdvanceOperation(ref cashExpense, cashInput, categoryRepository);
+
+			if(cashExpense != null)
+			{
+				uow.Save(cashExpense);
+			}
+
+			cashExpense?.UpdateWagesOperations(uow);
+
+			uow.Save();
+		}
+
+		public string UnclosedRouteListStrings(IUnitOfWork uow) => string.Join("\n",
+			(UnclosedRouteLists(uow).Select(x => $" - № {x.Id}  от {x.Date.ToShortDateString()}").ToArray()));
+
+		public class NewDriverAdvanceRouteListNode
+		{
+			public int Id { get; set; }
+			public DateTime Date { get; set; }
+		}
+	}
+}

--- a/VodovozBusiness/Models/NewDriverAdvanceModel.cs
+++ b/VodovozBusiness/Models/NewDriverAdvanceModel.cs
@@ -1,13 +1,11 @@
-﻿using NHibernate.Transform;
-using QS.DomainModel.UoW;
+﻿using QS.DomainModel.UoW;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using FluentNHibernate.Conventions;
 using Vodovoz.Domain.Cash;
-using Vodovoz.Domain.Employees;
 using Vodovoz.Domain.Logistic;
 using Vodovoz.EntityRepositories.Cash;
+using Vodovoz.EntityRepositories.Logistic;
 using Vodovoz.Parameters;
 
 namespace Vodovoz.Models
@@ -15,71 +13,32 @@ namespace Vodovoz.Models
 	public class NewDriverAdvanceModel
 	{
 		private readonly INewDriverAdvanceParametersProvider _newDriverAdvanceParametersProvider;
+		private readonly IRouteListRepository _routeListRepository;
 		private readonly RouteList _routeList;
+		private IList<NewDriverAdvanceRouteListNode> _unclosedRouteLists;
 
-		public NewDriverAdvanceModel(INewDriverAdvanceParametersProvider newDriverAdvanceParametersProvider, RouteList routeList)
+		public NewDriverAdvanceModel(INewDriverAdvanceParametersProvider newDriverAdvanceParametersProvider, IRouteListRepository routeListRepository, RouteList routeList)
 		{
 			_newDriverAdvanceParametersProvider = newDriverAdvanceParametersProvider ?? throw new ArgumentNullException(nameof(newDriverAdvanceParametersProvider));
+			_routeListRepository = routeListRepository ?? throw new ArgumentNullException(nameof(routeListRepository));
 			_routeList = routeList ?? throw new ArgumentNullException(nameof(routeList));
-		}
-
-		public IList<NewDriverAdvanceRouteListNode> UnclosedRouteLists(IUnitOfWork uow)
-		{
-			NewDriverAdvanceRouteListNode resultAlias = null;
-
-			var unclosedRouteLists = uow.Session.QueryOver<RouteList>()
-				.Where(x => x.Date < _routeList.Date)
-				.And(x => x.Status != RouteListStatus.Closed)
-				.And(x => x.Driver.Id == _routeList.Driver.Id)
-				.SelectList(list => list
-					.Select(x => x.Id).WithAlias(() => resultAlias.Id)
-					.Select(x => x.Date).WithAlias(() => resultAlias.Date)
-				)
-				.TransformUsing(Transformers.AliasToBean<NewDriverAdvanceRouteListNode>())
-				.List<NewDriverAdvanceRouteListNode>();
-
-			return unclosedRouteLists;
 		}
 
 		public bool NeedNewDriverAdvance(IUnitOfWork uow)
 		{
-			var hasAdvance = uow.Session.QueryOver<Expense>()
-				.Where(x => x.RouteListClosing.Id == _routeList.Id)
-				.And(x => x.Employee.Id == _routeList.Driver.Id)
-				.And(x=> x.TypeOperation == ExpenseType.EmployeeAdvance)
-				.RowCount() > 0;
-
-			if(hasAdvance)
+			if(_routeListRepository.HasEmployeeAdvance(uow, _routeList.Id, _routeList.Driver.Id))
 			{
 				return false;
 			}
 
-			Employee employeeAlias = null;
+			DateTime firstAdvanceDate = _routeListRepository.GetDateByDriverWorkingDayNumber(uow, _routeList.Driver.Id, 
+				_newDriverAdvanceParametersProvider.NewDriverAdvanceFirstDay, CarTypeOfUse.DriverCar);
 
-			var firstAdvanceDate = uow.Session.QueryOver<RouteList>()
-				.JoinAlias(x => x.Driver, () => employeeAlias)
-				.Where(x => x.Driver.Id == _routeList.Driver.Id)
-				.And(() => employeeAlias.DriverOf == CarTypeOfUse.DriverCar)
-				.SelectList(list => list
-					.SelectGroup(x => x.Date))
-				.OrderBy(x => x.Date).Asc
-				.Skip(_newDriverAdvanceParametersProvider.NewDriverAdvanceFirstDay - 1)
-				.Take(1)
-				.FutureValue<DateTime>();
+			DateTime lastAdvanceDate = _routeListRepository.GetDateByDriverWorkingDayNumber(uow, _routeList.Driver.Id,
+				_newDriverAdvanceParametersProvider.NewDriverAdvanceLastDay, CarTypeOfUse.DriverCar);
 
-			var lastAdvanceDate = uow.Session.QueryOver<RouteList>()
-				.JoinAlias(x => x.Driver, () => employeeAlias)
-				.Where(x => x.Driver.Id == _routeList.Driver.Id)
-				.And(() => employeeAlias.DriverOf == CarTypeOfUse.DriverCar)
-				.SelectList(list => list
-					.SelectGroup(x => x.Date))
-				.OrderBy(x => x.Date).Asc
-				.Skip(_newDriverAdvanceParametersProvider.NewDriverAdvanceLastDay - 1)
-				.Take(1)
-				.FutureValue<DateTime>();
-
-			var needNewDriverAdvance = (firstAdvanceDate.Value <= _routeList.Date)
-									&& (_routeList.Date <= lastAdvanceDate.Value);
+			bool needNewDriverAdvance = (firstAdvanceDate <= _routeList.Date)
+			                           && (_routeList.Date <= lastAdvanceDate);
 
 			return needNewDriverAdvance;
 		}
@@ -96,17 +55,12 @@ namespace Vodovoz.Models
 			}
 
 			cashExpense?.UpdateWagesOperations(uow);
-
-			uow.Save();
 		}
 
+		public IList<NewDriverAdvanceRouteListNode> UnclosedRouteLists(IUnitOfWork uow) =>
+			_unclosedRouteLists ?? (_unclosedRouteLists = _routeListRepository.GetOldUnclosedRouteLists(uow, _routeList.Date, _routeList.Driver.Id));
+			
 		public string UnclosedRouteListStrings(IUnitOfWork uow) => string.Join("\n",
 			(UnclosedRouteLists(uow).Select(x => $" - № {x.Id}  от {x.Date.ToShortDateString()}").ToArray()));
-
-		public class NewDriverAdvanceRouteListNode
-		{
-			public int Id { get; set; }
-			public DateTime Date { get; set; }
-		}
 	}
 }

--- a/VodovozBusiness/Parameters/NewDriverAdvanceParametersProvider.cs
+++ b/VodovozBusiness/Parameters/NewDriverAdvanceParametersProvider.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Vodovoz.Services;
+
+namespace Vodovoz.Parameters
+{
+	public class NewDriverAdvanceParametersProvider : INewDriverAdvanceParametersProvider
+	{
+		private readonly IParametersProvider _parametersProvider;
+
+		public NewDriverAdvanceParametersProvider(IParametersProvider parametersProvider)
+		{
+			this._parametersProvider = parametersProvider ?? throw new ArgumentNullException(nameof(parametersProvider));
+		}
+
+		public int NewDriverAdvanceFirstDay => _parametersProvider.GetIntValue("new_driver_advance_first_day");
+		public int NewDriverAdvanceLastDay => _parametersProvider.GetIntValue("new_driver_advance_last_day");
+		public decimal NewDriverAdvanceSum => _parametersProvider.GetDecimalValue ("new_driver_advance_sum");
+	}
+}

--- a/VodovozBusiness/Services/INewDriverAdvanceParametersProvider.cs
+++ b/VodovozBusiness/Services/INewDriverAdvanceParametersProvider.cs
@@ -1,0 +1,9 @@
+﻿namespace Vodovoz.Parameters
+{
+	public interface INewDriverAdvanceParametersProvider
+	{
+		int NewDriverAdvanceFirstDay { get; }
+		int NewDriverAdvanceLastDay { get; }
+		decimal NewDriverAdvanceSum { get; }
+	}
+}

--- a/VodovozBusiness/VodovozBusiness.csproj
+++ b/VodovozBusiness/VodovozBusiness.csproj
@@ -309,6 +309,7 @@
     <Compile Include="HibernateMapping\Logistic\Drivers\DriverDistrictPrioritySetMap.cs" />
     <Compile Include="HibernateMapping\Logistic\Drivers\DriverWorkScheduleMap.cs" />
     <Compile Include="HibernateMapping\Logistic\Drivers\DriverWorkScheduleSetMap.cs" />
+    <Compile Include="Models\NewDriverAdvanceModel.cs" />
     <Compile Include="Models\PremiumRaskatGAZelleWageModel.cs" />
     <Compile Include="Models\FinancialDistrictProvider.cs" />
     <Compile Include="Models\IFinancialDistrictProvider.cs" />
@@ -324,9 +325,11 @@
     <Compile Include="Parameters\ExpenseParametersProvider.cs" />
     <Compile Include="Parameters\GeographicGroupParametersProvider.cs" />
     <Compile Include="Parameters\IExpenseParametersProvider.cs" />
+    <Compile Include="Services\INewDriverAdvanceParametersProvider.cs" />
     <Compile Include="Parameters\IParametersProvider.cs" />
     <Compile Include="Parameters\IReportDefaultsProvider.cs" />
     <Compile Include="Parameters\NomenclatureParametersProvider.cs" />
+    <Compile Include="Parameters\NewDriverAdvanceParametersProvider.cs" />
     <Compile Include="Parameters\ProductionWarehouseMovementReportProvider.cs" />
     <Compile Include="Parameters\OrganizationCashTransferDocumentParametersProvider.cs" />
     <Compile Include="Parameters\NomenclaturePlanParametersProvider.cs" />


### PR DESCRIPTION
Добавлен функционал при закрытии МЛ: новые водители на своём авто на время испытательного срока (с 6-го по 60-й рабочий день) получают аванс  (дни и сумма аванса задаются в параметрах). 
- Рабочими днями считаются те дни, в которых был хотя бы один МЛ.
- Первым рабочим днем считается день, в котором был первый МЛ у этого водителя.
- Если ЗП водителя за МЛ меньше суммы аванса в параметрах, то выдаётся аванс в 50% от суммы ЗП за МЛ.
- Если есть незакрытые МЛ прошлых дней, то аванс не выдаётся и выводится вопрос: "У водителя есть незакрытые МЛ с №№ на даты. Текущий МЛ будет закрыт без выдачи аванса. Продолжить или отменить?". При отмене МЛ не закрывается, при подтверждении закрывается без аванса.
- При подтверждении закрытия МЛ добавлен вывод суммарной информации по суммам приходных ордеров, расходных ордеров без авансов, отдельно авансов.