### PR TITLE
Выпилил устаревшие проверки на дату доставки заказа и подбор организации по этой дате

### DIFF
--- a/Services/Library/SmsPaymentService/SmsPaymentDTOFactory.cs
+++ b/Services/Library/SmsPaymentService/SmsPaymentDTOFactory.cs
@@ -23,10 +23,6 @@ namespace SmsPaymentService
 			{
 				throw new ArgumentNullException(nameof(order));
 			}
-			if(!order.DeliveryDate.HasValue)
-			{
-				throw new InvalidOperationException("Order delivery date cannot be null");
-			}
 
 			var newSmsPaymentDTO = new SmsPaymentDTO
 			{
@@ -44,7 +40,7 @@ namespace SmsPaymentService
 						uow,
 						PaymentType.ByCard,
 						order.SelfDelivery,
-						order.DeliveryDate.Value,
+						order.CreateDate,
 						order.OrderItems,
 						paymentFrom,
 						order.DeliveryPoint?.District?.GeographicGroup

--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -915,15 +915,6 @@ namespace Vodovoz.Domain.Orders
 
 		public virtual IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
 		{
-			//FIXME Убрать эту проверку после 2021-10-14
-			if(DeliveryDate == Convert.ToDateTime("2021-10-13") && PaymentType == PaymentType.Terminal)
-			{
-				yield return new ValidationResult(
-					"Нельзя принимать заказы на 13.10.21 с формой оплаты \"Терминал\". " +
-					"Выберите другую дату или другую форму оплаты",
-					new[] { nameof(DeliveryDate), nameof(PaymentType) });
-			}
-
 			if(DeliveryDate == null || DeliveryDate == default(DateTime))
 				yield return new ValidationResult("В заказе не указана дата доставки.",
 					new[] { this.GetPropertyName(o => o.DeliveryDate) });
@@ -1551,10 +1542,6 @@ namespace Vodovoz.Domain.Orders
 			}
 
 			if(Client == null)
-			{
-				return;
-			}
-			if(DeliveryDate == null)
 			{
 				return;
 			}

--- a/VodovozBusiness/Models/IOrganizationProvider.cs
+++ b/VodovozBusiness/Models/IOrganizationProvider.cs
@@ -13,7 +13,7 @@ namespace Vodovoz.Models
 	{
 		Organization GetOrganization(IUnitOfWork uow, Order order);
 
-		Organization GetOrganization(IUnitOfWork uow, PaymentType paymentType, bool isSelfDelivery, DateTime deliveryDate,
+		Organization GetOrganization(IUnitOfWork uow, PaymentType paymentType, bool isSelfDelivery, DateTime? orderCreateDate,
 			IEnumerable<OrderItem> orderItems = null, PaymentFrom paymentFrom = null, GeographicGroup geographicGroup = null);
 
 		Organization GetOrganizationForOrderWithoutShipment(IUnitOfWork uow, OrderWithoutShipmentForAdvancePayment order);

--- a/VodovozBusiness/Models/IOrganizationProvider.cs
+++ b/VodovozBusiness/Models/IOrganizationProvider.cs
@@ -14,7 +14,7 @@ namespace Vodovoz.Models
 		Organization GetOrganization(IUnitOfWork uow, Order order);
 
 		Organization GetOrganization(IUnitOfWork uow, PaymentType paymentType, bool isSelfDelivery, DateTime? orderCreateDate,
-			IEnumerable<OrderItem> orderItems = null, PaymentFrom paymentFrom = null, GeographicGroup geographicGroup = null);
+			IEnumerable<OrderItem> orderItems, PaymentFrom paymentFrom, GeographicGroup geographicGroup);
 
 		Organization GetOrganizationForOrderWithoutShipment(IUnitOfWork uow, OrderWithoutShipmentForAdvancePayment order);
 	}

--- a/VodovozBusiness/Models/Stage2OrganizationProvider.cs
+++ b/VodovozBusiness/Models/Stage2OrganizationProvider.cs
@@ -42,8 +42,8 @@ namespace Vodovoz.Models
 				order.PaymentByCardFrom, order.DeliveryPoint?.District?.GeographicGroup);
 		}
 
-		public Organization GetOrganization(IUnitOfWork uow, PaymentType paymentType, bool isSelfDelivery, DateTime? orderCreateDate = null,
-			IEnumerable<OrderItem> orderItems = null, PaymentFrom paymentFrom = null, GeographicGroup geographicGroup = null)
+		public Organization GetOrganization(IUnitOfWork uow, PaymentType paymentType, bool isSelfDelivery, DateTime? orderCreateDate,
+			IEnumerable<OrderItem> orderItems, PaymentFrom paymentFrom, GeographicGroup geographicGroup)
 		{
 			if(uow == null)
 			{
@@ -60,8 +60,8 @@ namespace Vodovoz.Models
 				: GetOrganizationForOtherOptions(uow, paymentType, orderCreateDate, paymentFrom, geographicGroup);
 		}
 
-		private Organization GetOrganizationForSelfDelivery(IUnitOfWork uow, PaymentType paymentType, DateTime? orderCreateDate = null,
-			PaymentFrom paymentFrom = null, GeographicGroup geographicGroup = null)
+		private Organization GetOrganizationForSelfDelivery(IUnitOfWork uow, PaymentType paymentType, DateTime? orderCreateDate,
+			PaymentFrom paymentFrom, GeographicGroup geographicGroup)
 		{
 			int organizationId;
 			switch(paymentType)
@@ -105,7 +105,7 @@ namespace Vodovoz.Models
 		}
 
 		private Organization GetOrganizationForOtherOptions(IUnitOfWork uow, PaymentType paymentType, DateTime? orderCreateDate,
-			PaymentFrom paymentFrom = null, GeographicGroup geographicGroup = null)
+			PaymentFrom paymentFrom, GeographicGroup geographicGroup)
 		{
 			int organizationId;
 			switch(paymentType)
@@ -158,7 +158,7 @@ namespace Vodovoz.Models
 				x.Nomenclature.OnlineStore != null && x.Nomenclature.OnlineStore.Id != _orderParametersProvider.OldInternalOnlineStoreId);
 		}
 
-		private int GetOrganizationIdForByCard(PaymentFrom paymentFrom = null, GeographicGroup geographicGroup = null, DateTime? orderCreateDate = null)
+		private int GetOrganizationIdForByCard(PaymentFrom paymentFrom, GeographicGroup geographicGroup, DateTime? orderCreateDate)
 		{
 			if(paymentFrom == null)
 			{

--- a/VodovozBusiness/Parameters/IParametersProvider.cs
+++ b/VodovozBusiness/Parameters/IParametersProvider.cs
@@ -10,6 +10,7 @@
         int GetIntValue(string parameterId);
         string GetStringValue(string parameterId);
         bool GetBoolValue(string parameterId);
+        T GetValue<T>(string parameterId) where T : struct;
 
         void RefreshParameters();
     }

--- a/VodovozBusiness/Parameters/OrganizationParametersProvider.cs
+++ b/VodovozBusiness/Parameters/OrganizationParametersProvider.cs
@@ -22,5 +22,7 @@ namespace Vodovoz.Parameters
         public int VodovozDeshitsOrganizationId => _parametersProvider.GetIntValue("vodovoz_Deshits_organization_id");
         public int CommonCashDistributionOrganisationId =>
             _parametersProvider.GetIntValue("common_cash_distribution_organisation_id");
+        public TimeSpan LatestCreateTimeForSouthOrganizationInByCardOrder =>
+	        _parametersProvider.GetValue<TimeSpan>("latest_create_time_for_south_organization_in_by_card_order");
     }
 }

--- a/VodovozBusiness/Services/IOrganizationParametersProvider.cs
+++ b/VodovozBusiness/Services/IOrganizationParametersProvider.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Vodovoz.Services
 {
     public interface IOrganizationParametersProvider
@@ -12,5 +14,6 @@ namespace Vodovoz.Services
         int VodovozNorthOrganizationId { get; }
         int VodovozDeshitsOrganizationId { get; }
         int CommonCashDistributionOrganisationId { get; }
+        TimeSpan LatestCreateTimeForSouthOrganizationInByCardOrder { get; }
     }
 }


### PR DESCRIPTION
Заказы с временем создания менее чем указано в параметрах, оплаченные по смс и принадлежащие к Северной части города теперь встают на Южную организацию
Добавил в ParametersProvider возможность получать параметр любого значащего типа через дженерик параметр