### PR TITLE
Дополнил условие скрытия надписи печатаемых документов

### DIFF
--- a/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -748,7 +748,7 @@ namespace Vodovoz
 				hboxDocumentType.Add(torg12OnlyLabel);
 				torg12OnlyLabel.Show();
 			}
-			else if(hboxDocumentType.Children.Contains(torg12OnlyLabel))
+			else if(!Entity.IsCashlessPaymentTypeAndOrganizationWithoutVAT && hboxDocumentType.Children.Contains(torg12OnlyLabel))
 			{
 				hboxDocumentType.Remove(torg12OnlyLabel);
 				hboxDocumentType.Add(enumDocumentType);


### PR DESCRIPTION
Некорректно работало скрытие комбо с типами распечатываемых доков и замена его на надпись Торг-12 2шт