### PR TITLE
Запрет на удаление арендных строк заказа

### DIFF
--- a/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -2030,6 +2030,21 @@ namespace Vodovoz
 
 		private void RemoveOrderItem(OrderItem item)
 		{
+			var orderEquipment = Entity.OrderEquipments.FirstOrDefault(x => x.OrderRentDepositItem == item || x.OrderRentServiceItem == item);
+
+			if(orderEquipment != null)
+			{
+				var existingRentDepositItem = orderEquipment.OrderRentDepositItem;
+				var existingNonFreeRentServiceItem = orderEquipment.OrderRentServiceItem;
+			
+				if(existingRentDepositItem != null || existingNonFreeRentServiceItem != null)
+				{
+					MessageDialogHelper.RunWarningDialog(
+						$"Нельзя удалить строку заказа. Сначала удалите связанную с ней строку оборудования {orderEquipment.FullNameString}");
+					return;
+				}
+			}
+
 			Entity.RemoveItem(item);
 		}
 

--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -2391,9 +2391,33 @@ namespace Vodovoz.Domain.Orders
 
 		public virtual void RemoveEquipment(OrderEquipment item)
 		{
-			ObservableOrderEquipments.Remove(item);
+			var rentDepositOrderItem = item.OrderRentDepositItem;
+			var rentServiceOrderItem = item.OrderRentServiceItem;
+			var totalEquipmentCountForDeposit = 0;
+			var totalEquipmentCountForService = 0;
+			
+			if(rentDepositOrderItem != null)
+			{
+				totalEquipmentCountForDeposit = GetRentEquipmentTotalCountForDepositItem(rentDepositOrderItem);
+			}
+			if(rentServiceOrderItem != null)
+			{
+				totalEquipmentCountForService = GetRentEquipmentTotalCountForServiceItem(rentServiceOrderItem);
+			}
+
+			if(totalEquipmentCountForDeposit > item.Count || totalEquipmentCountForService > item.Count)
+			{
+				ObservableOrderEquipments.Remove(item);
+				UpdateRentsCount();
+			}
+			else if(totalEquipmentCountForDeposit == item.Count || totalEquipmentCountForService == item.Count)
+			{
+				ObservableOrderEquipments.Remove(item);
+				RemoveOrderItem(rentDepositOrderItem);
+				RemoveOrderItem(rentServiceOrderItem);
+			}
+			
 			UpdateDocuments();
-			UpdateRentsCount();
 		}
 
 		/// <summary>

--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -2405,16 +2405,16 @@ namespace Vodovoz.Domain.Orders
 				totalEquipmentCountForService = GetRentEquipmentTotalCountForServiceItem(rentServiceOrderItem);
 			}
 
-			if(totalEquipmentCountForDeposit > item.Count || totalEquipmentCountForService > item.Count)
-			{
-				ObservableOrderEquipments.Remove(item);
-				UpdateRentsCount();
-			}
-			else if(totalEquipmentCountForDeposit == item.Count || totalEquipmentCountForService == item.Count)
+			if(totalEquipmentCountForDeposit == item.Count || totalEquipmentCountForService == item.Count)
 			{
 				ObservableOrderEquipments.Remove(item);
 				RemoveOrderItem(rentDepositOrderItem);
 				RemoveOrderItem(rentServiceOrderItem);
+			}
+			else
+			{
+				ObservableOrderEquipments.Remove(item);
+				UpdateRentsCount();
 			}
 			
 			UpdateDocuments();


### PR DESCRIPTION
Запрещаем удаление арендных строк заказа, если есть связанное с ними оборудование
При удалении последнего связанного оборудования, удаляем и строки заказа по аренде