### PR TITLE
Хотфикс аналитики эксплуатации ТС

### DIFF
--- a/VodovozViewModels/ViewModels/Reports/CarsExploitationReportViewModel.cs
+++ b/VodovozViewModels/ViewModels/Reports/CarsExploitationReportViewModel.cs
@@ -239,13 +239,19 @@ namespace Vodovoz.ViewModels.Reports
 				Car carAlias = null;
 				Employee assignedDriverAlias = null;
 				CarModel carModelAlias = null;
+				CarVersion carVersionAlias = null;
 
 				var carsQuery = UoW.Session.QueryOver(() => carAlias)
 					.Inner.JoinAlias(() => carAlias.CarModel, () => carModelAlias)
 					.Left.JoinAlias(() => carAlias.Driver, () => assignedDriverAlias)
+					.JoinEntityAlias(() => carVersionAlias,
+						() => carVersionAlias.Car.Id == carAlias.Id
+						      && carVersionAlias.StartDate <= endDate
+						      && (carVersionAlias.EndDate == null || carVersionAlias.EndDate >= StartDate))
 					.Where(() => !carAlias.IsArchive)
 					.And(() => assignedDriverAlias.Id == null || !assignedDriverAlias.VisitingMaster)
-					.And(() => carModelAlias.CarTypeOfUse != CarTypeOfUse.Truck);
+					.And(() => carModelAlias.CarTypeOfUse != CarTypeOfUse.Truck)
+					.And(() => carVersionAlias.CarOwnType == carOwnType);
 
 				if(carTypeOfUse != null)
 				{


### PR DESCRIPTION
Для признака "авто без движений" добавил учёт фильтра по принадлежности ТС из версии автомобилей.