### PR TITLE
3968 Дополнения в талоны разгрузки/погрузки (доп.вопросы)

### DIFF
--- a/Vodovoz/ViewWidgets/Store/ReturnsReceptionView.cs
+++ b/Vodovoz/ViewWidgets/Store/ReturnsReceptionView.cs
@@ -237,6 +237,7 @@ namespace Vodovoz
 					.JoinEntityAlias(() => routeListItemAlias, () => routeListItemAlias.Order.Id == orderAlias.Id)
 					.Where(() => routeListItemAlias.RouteList.Id == RouteList.Id)
 					.And(() => orderEquipmentAlias.Nomenclature.Id == nomenclatureAlias.Id)
+					.And(() => orderEquipmentAlias.Direction == Domain.Orders.Direction.Deliver)
 					.And(() => orderAlias.IsFastDelivery == true)
 					.Select(Projections.Sum(() => orderEquipmentAlias.Count));
 

--- a/VodovozBusiness/Domain/Logistic/Discrepancy.cs
+++ b/VodovozBusiness/Domain/Logistic/Discrepancy.cs
@@ -36,13 +36,18 @@ namespace Vodovoz.Domain.Logistic
 		/// </summary>
 		public decimal AdditionaLoading { get; set; }
 
+		/// <summary>
+		/// Заказы с доставкой за час
+		/// </summary>
+		public decimal NomenclaturesInFastDeliveryOrders { get; set; }
+
 		public bool Trackable { get; set; }
 		public bool UseFine { get; set; }
 
 		/// <summary>
 		/// Остаток
 		/// </summary>
-		public decimal Remainder => FromWarehouse + ToWarehouse - ClientRejected - PickedUpFromClient - AdditionaLoading;
+		public decimal Remainder => FromWarehouse + ToWarehouse - ClientRejected - PickedUpFromClient - AdditionaLoading + NomenclaturesInFastDeliveryOrders;
 
 		/// <summary>
 		/// Недовоз

--- a/VodovozBusiness/Domain/Logistic/RouteList.cs
+++ b/VodovozBusiness/Domain/Logistic/RouteList.cs
@@ -968,9 +968,9 @@ namespace Vodovoz.Domain.Logistic
 
 			if(AdditionalLoadingDocument != null)
 			{
+				var fastDeliveryOrdersItemsInRL = _routeListRepository.GetFastDeliveryOrdersItemsInRL(UoW, this);
 				foreach(var item in AdditionalLoadingDocument.Items)
 				{
-					var fastDeliveryOrdersItemsInRL = _routeListRepository.GetFastDeliveryOrdersItemsInRL(UoW, this);
 					var fastDeliveryItem = fastDeliveryOrdersItemsInRL.FirstOrDefault(x => x.NomenclatureId == item.Nomenclature.Id);
 					AddDiscrepancy(result, new Discrepancy
 					{

--- a/VodovozBusiness/Domain/Logistic/RouteList.cs
+++ b/VodovozBusiness/Domain/Logistic/RouteList.cs
@@ -970,10 +970,13 @@ namespace Vodovoz.Domain.Logistic
 			{
 				foreach(var item in AdditionalLoadingDocument.Items)
 				{
+					var fastDeliveryOrdersItemsInRL = _routeListRepository.GetFastDeliveryOrdersItemsInRL(UoW, this);
+					var fastDeliveryItem = fastDeliveryOrdersItemsInRL.FirstOrDefault(x => x.NomenclatureId == item.Nomenclature.Id);
 					AddDiscrepancy(result, new Discrepancy
 					{
 						Nomenclature = item.Nomenclature,
 						AdditionaLoading = item.Amount,
+						NomenclaturesInFastDeliveryOrders = fastDeliveryItem?.Amount ?? 0,
 						Name = item.Nomenclature.Name
 					});
 				}
@@ -997,6 +1000,7 @@ namespace Vodovoz.Domain.Logistic
 				existingDiscrepancy.ToWarehouse += item.ToWarehouse;
 				existingDiscrepancy.FromWarehouse += item.FromWarehouse;
 				existingDiscrepancy.AdditionaLoading += item.AdditionaLoading;
+				existingDiscrepancy.NomenclaturesInFastDeliveryOrders += item.NomenclaturesInFastDeliveryOrders;
 			}
 		}
 
@@ -2277,7 +2281,9 @@ namespace Vodovoz.Domain.Logistic
 					var loaded = loadedNomenclatures.FirstOrDefault(x => x.NomenclatureId == n.NomenclatureId);
 					decimal loadedAmount = 0;
 					if(loaded != null)
+					{
 						loadedAmount = loaded.Amount;
+					}
 					if(loadedAmount < n.Amount) {
 						notLoadedNomenclatures.Add(new RouteListControlNotLoadedNode {
 							NomenclatureId = n.NomenclatureId,

--- a/VodovozBusiness/EntityRepositories/Logistic/IRouteListRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Logistic/IRouteListRepository.cs
@@ -21,6 +21,7 @@ namespace Vodovoz.EntityRepositories.Logistic
 		QueryOver<RouteList> GetRoutesAtDay(DateTime date, List<int> geographicGroupsIds);
 		IList<GoodsInRouteListResult> GetGoodsAndEquipsInRL(IUnitOfWork uow, RouteList routeList, ISubdivisionRepository subdivisionRepository = null, Warehouse warehouse = null);
 		IList<GoodsInRouteListResult> GetGoodsInRLWithoutEquipments(IUnitOfWork uow, RouteList routeList);
+		IList<GoodsInRouteListResult> GetFastDeliveryOrdersItemsInRL(IUnitOfWork uoW, RouteList routeList);
 		GoodsInRouteListResult GetTerminalInRL(IUnitOfWork uow, RouteList routeList, Warehouse warehouse);
 		IList<GoodsInRouteListResult> GetEquipmentsInRL(IUnitOfWork uow, RouteList routeList);
 		IList<GoodsInRouteListResult> AllGoodsLoaded(IUnitOfWork uow, RouteList routeList, CarLoadDocument excludeDoc = null);

--- a/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
@@ -440,6 +440,7 @@ namespace Vodovoz.EntityRepositories.Logistic
 				.Where(() => orderAlias.IsFastDelivery)
 				.And(() => routeListItemAlias.RouteList.Id == routeList.Id)
 				.And(() => !routeListItemAlias.WasTransfered || (routeListItemAlias.WasTransfered && routeListItemAlias.NeedToReload))
+				.And(() => orderEquipmentAlias.Direction == Direction.Deliver)
 				.SelectList(list => list
 					.SelectGroup(() => orderEquipmentAlias.Nomenclature.Id).WithAlias(() => equipmentResultAlias.NomenclatureId)
 					.SelectSum(() => orderEquipmentAlias.Count).WithAlias(() => equipmentResultAlias.Amount))

--- a/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
@@ -112,6 +112,11 @@ namespace Vodovoz.EntityRepositories.Logistic
 				if (cashSubdivisions.Contains(warehouse.OwningSubdivision))
 				{
 					terminal = GetTerminalInRLWithSpecialRequirements(uow, routeList, warehouse);
+					if(routeList.AdditionalLoadingDocument != null)
+					{
+						result.AddRange(GetGoodsInRLWithoutEquipmentsWithSpecialRequirements(uow, routeList).ToList());
+						result.AddRange(GetEquipmentsInRLWithSpecialRequirements(uow, routeList).ToList());
+					}
 				}
 				else
 				{


### PR DESCRIPTION
 1. В закрытии МЛ исправлено неверное значение в колонке Недопогрузка для заказов с доставкой за час.
 2. Фикс отгружаемого количества в талоне погрузки при заполнении для склада для МЛ с доставкой за час.
 3. Учёт оборудования в ожидаемом количестве талона разгрузки и в возвратах/недовозах диалога закрытия МЛ. 