### PR TITLE
3949 добавил в валидацию проверку цен в перенесенном заказе

### DIFF
--- a/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -371,6 +371,7 @@ namespace Vodovoz
 				.CopyAttachedDocuments();
 			
 			Entity.IsCopiedFromUndelivery = true;
+			Entity.CopiedOrderFromUndelivery = copying.GetCopiedOrder;
 			if(copying.GetCopiedOrder.PaymentType == PaymentType.ByCard
 				&& MessageDialogHelper.RunQuestionDialog("Перенести на выбранный заказ Оплату по Карте?"))
 			{

--- a/VodovozBusiness/Domain/Goods/OrderItemComparerForCopyingFromUndelivery.cs
+++ b/VodovozBusiness/Domain/Goods/OrderItemComparerForCopyingFromUndelivery.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using Vodovoz.Domain.Orders;
+
+namespace Vodovoz.Domain.Goods
+{
+	public class OrderItemComparerForCopyingFromUndelivery : IEqualityComparer<OrderItem>
+	{
+		public bool Equals(OrderItem x, OrderItem y)
+		{
+			if(Object.ReferenceEquals(x, y))
+			{
+				return true;
+			}
+
+			if(Object.ReferenceEquals(x, null) || Object.ReferenceEquals(y, null))
+			{
+				return false;
+			}
+			
+			return x.Nomenclature.Id == y.Nomenclature.Id;
+		}
+
+		public int GetHashCode(OrderItem orderItem)
+		{
+			if(Object.ReferenceEquals(orderItem, null))
+			{
+				return 0;
+			}
+			
+			return orderItem.Nomenclature.Id.GetHashCode();
+		}
+	}
+}

--- a/VodovozBusiness/EntityRepositories/Undeliveries/IUndeliveredOrdersRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Undeliveries/IUndeliveredOrdersRepository.cs
@@ -16,5 +16,6 @@ namespace Vodovoz.EntityRepositories.Undeliveries
 		IList<int> GetListOfUndeliveryIdsForDriver(IUnitOfWork uow, Employee driver);
 		IList<object[]> GetGuiltyAndCountForDates(IUnitOfWork uow, DateTime? start = null, DateTime? end = null);
 		decimal GetUndelivered19LBottlesQuantity(IUnitOfWork uow, DateTime? start = null, DateTime? end = null);
+		Order GetOldOrderFromUndeliveredByNewOrderId(IUnitOfWork uow, int newOrderId);
 	}
 }

--- a/VodovozBusiness/EntityRepositories/Undeliveries/UndeliveredOrdersRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Undeliveries/UndeliveredOrdersRepository.cs
@@ -195,5 +195,16 @@ namespace Vodovoz.EntityRepositories.Undeliveries
 
 			return bottles19L ?? 0;
 		}
+
+		public Order GetOldOrderFromUndeliveredByNewOrderId(IUnitOfWork uow, int newOrderId)
+		{
+			Order oldOrderAlias = null;
+
+			return uow.Session.QueryOver<UndeliveredOrder>()
+				.JoinAlias(u => u.OldOrder, () => oldOrderAlias)
+				.Where(u => u.NewOrder.Id == newOrderId)
+				.Select(Projections.Entity(() => oldOrderAlias))
+				.SingleOrDefault<Order>();
+		}
 	}
 }

--- a/VodovozBusiness/VodovozBusiness.csproj
+++ b/VodovozBusiness/VodovozBusiness.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Domain\FinancialDistrict.cs" />
     <Compile Include="Domain\FinancialDistrictsSet.cs" />
     <Compile Include="Domain\Goods\AdditionalLoadingNomenclatureDistribution.cs" />
+    <Compile Include="Domain\Goods\OrderItemComparerForCopyingFromUndelivery.cs" />
     <Compile Include="Domain\Goods\NomenclaturePurchasePrice.cs" />
     <Compile Include="Domain\Goods\NomenclatureFixedPrice.cs" />
     <Compile Include="Domain\EntityFactories\NomenclatureFixedPriceFactory.cs" />


### PR DESCRIPTION
Проверяем цены в перенесенном заказе через недовоз
Позиции, что перенесены из старого заказа, не должны быть меньше по ценам
Новые позиции, которые были добавлены после переноса, валидируются по старой схеме: цена должна быть не меньше фиксы или номенклатурного прайса