### PR TITLE
4031 Обновление диалога ручного распределения

### DIFF
--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -2723,16 +2723,22 @@ namespace Vodovoz.Domain.Orders
 			}
 		}
 
-		public virtual void UpdateOrderPaymentStatus()
+		public virtual void UpdateOrderPaymentStatus(decimal canceledSum)
 		{
 			var allocatedSum = _paymentItemsRepository.GetAllocatedSumForOrder(UoW, Id);
-			
-			OrderPaymentStatus =
-				allocatedSum >= OrderSum
-					? OrderPaymentStatus.Paid
-					: allocatedSum == 0
-						? OrderPaymentStatus.UnPaid
-						: OrderPaymentStatus.PartiallyPaid;
+
+			if(allocatedSum == 0 || allocatedSum - canceledSum == 0)
+			{
+				OrderPaymentStatus = OrderPaymentStatus.UnPaid;
+			}
+			else if(allocatedSum - canceledSum > OrderSum)
+			{
+				OrderPaymentStatus = OrderPaymentStatus.Paid;
+			}
+			else
+			{
+				OrderPaymentStatus = OrderPaymentStatus.PartiallyPaid;
+			}
 		}
 
 		/// <summary>

--- a/VodovozBusiness/Domain/Payments/Payment.cs
+++ b/VodovozBusiness/Domain/Payments/Payment.cs
@@ -202,7 +202,7 @@ namespace Vodovoz.Domain.Payments
 			set => SetField(ref _isManuallyCreated, value);
 		}
 		
-		[Display(Name = "Пользователь, работающий с диалогом ручное распределение")]
+		[Display(Name = "Пользователь, работающий с диалогом ручного распределения")]
 		[IgnoreHistoryTrace]
 		public virtual UserBase CurrentEditorUser
 		{

--- a/VodovozBusiness/Domain/Payments/Payment.cs
+++ b/VodovozBusiness/Domain/Payments/Payment.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Gamma.Utilities;
 using QS.DomainModel.Entity.EntityPermissions;
 using QS.HistoryLog;
+using QS.Project.Domain;
 using Vodovoz.Controllers;
 using Vodovoz.Domain.Operations;
 using Vodovoz.Domain.Orders;
@@ -51,6 +52,7 @@ namespace Vodovoz.Domain.Payments
 		private Account _organizationAccount;
 		private ProfitCategory _profitCategory;
 		private Payment _refundedPayment;
+		private UserBase _currentEditorUser;
 		private IList<PaymentItem> _paymentItems = new List<PaymentItem>();
 
 		public virtual int Id { get; set; }
@@ -198,6 +200,14 @@ namespace Vodovoz.Domain.Payments
 		{
 			get => _isManuallyCreated;
 			set => SetField(ref _isManuallyCreated, value);
+		}
+		
+		[Display(Name = "Пользователь, работающий с диалогом ручное распределение")]
+		[IgnoreHistoryTrace]
+		public virtual UserBase CurrentEditorUser
+		{
+			get => _currentEditorUser;
+			set => SetField(ref _currentEditorUser, value);
 		}
 
 		public virtual string NumOrders { get; set; }

--- a/VodovozBusiness/Domain/Payments/PaymentItem.cs
+++ b/VodovozBusiness/Domain/Payments/PaymentItem.cs
@@ -102,7 +102,7 @@ namespace Vodovoz.Domain.Payments
 
 			if(needUpdateOrderPaymentStatus)
 			{
-				Order.UpdateOrderPaymentStatus();
+				Order.UpdateOrderPaymentStatus(Sum);
 			}
 		}
 		

--- a/VodovozBusiness/EntityRepositories/Payments/IPaymentsRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Payments/IPaymentsRepository.cs
@@ -18,6 +18,7 @@ namespace Vodovoz.EntityRepositories.Payments
 		IList<Payment> GetAllUndistributedPayments(IUnitOfWork uow, IProfitCategoryProvider profitCategoryProvider);
 		IList<Payment> GetAllDistributedPayments(IUnitOfWork uow);
 		Payment GetNotCancelledRefundedPayment(IUnitOfWork uow, int orderId);
+		IList<Payment> GetNotCancelledRefundedPayments(IUnitOfWork uow, int orderId);
 		IList<NotFullyAllocatedPaymentNode> GetAllNotFullyAllocatedPaymentsByClientAndOrg(
 			IUnitOfWork uow, int counterpartyId, int organizationId, bool allocateCompletedPayments);
 		IQueryOver<Payment, Payment> GetAllUnallocatedBalances(IUnitOfWork uow, int closingDocumentDeliveryScheduleId);

--- a/VodovozBusiness/EntityRepositories/Payments/PaymentsRepository.cs
+++ b/VodovozBusiness/EntityRepositories/Payments/PaymentsRepository.cs
@@ -123,6 +123,14 @@ namespace Vodovoz.EntityRepositories.Payments
 				.SingleOrDefault();
 		}
 		
+		public IList<Payment> GetNotCancelledRefundedPayments(IUnitOfWork uow, int orderId)
+		{
+			return uow.Session.QueryOver<Payment>()
+				.Where(p => p.RefundPaymentFromOrderId == orderId)
+				.And(p => p.Status != PaymentState.Cancelled)
+				.List();
+		}
+		
 		public IList<NotFullyAllocatedPaymentNode> GetAllNotFullyAllocatedPaymentsByClientAndOrg(
 			IUnitOfWork uow, int counterpartyId, int organizationId, bool allocateCompletedPayments)
 		{

--- a/VodovozBusiness/HibernateMapping/Accounting/PaymentMap.cs
+++ b/VodovozBusiness/HibernateMapping/Accounting/PaymentMap.cs
@@ -35,6 +35,7 @@ namespace Vodovoz.HibernateMapping.Accounting
 			References(x => x.CashlessMovementOperation).Column("cashless_movement_operation_id")
 				.Cascade.AllDeleteOrphan();
 			References(x => x.RefundedPayment).Column("refunded_payment_id");
+			References(x => x.CurrentEditorUser).Column("current_editor_user_id");
 
 			HasMany(x => x.PaymentItems).Cascade.AllDeleteOrphan().Inverse().LazyLoad().KeyColumn("payment_id");
 		}

--- a/VodovozViewModels/ViewModels/Payments/AutoPaymentMatching.cs
+++ b/VodovozViewModels/ViewModels/Payments/AutoPaymentMatching.cs
@@ -15,6 +15,7 @@ namespace Vodovoz.ViewModels.ViewModels.Payments
 	{
 		private readonly IUnitOfWork _uow;
 		private readonly OrderStatus[] _orderUndeliveredStatuses;
+		private readonly HashSet<int> addedOrderIdsToAllocate = new HashSet<int>();
 
 		public AutoPaymentMatching(IUnitOfWork uow, IOrderRepository orderRepository)
 		{
@@ -55,9 +56,15 @@ namespace Vodovoz.ViewModels.ViewModels.Payments
 
 				foreach(var order in orders)
 				{
+					if(addedOrderIdsToAllocate.Contains(order.Id))
+					{
+						return false;
+					}
+					
 					if(paymentSum >= order.OrderSum)
 					{
 						payment.AddPaymentItem(order);
+						addedOrderIdsToAllocate.Add(order.Id);
 						sb.AppendLine(order.Id.ToString());
 						paymentSum -= order.OrderSum;
 					}

--- a/VodovozViewModels/ViewModels/Payments/ManualPaymentMatchingViewModel.cs
+++ b/VodovozViewModels/ViewModels/Payments/ManualPaymentMatchingViewModel.cs
@@ -514,10 +514,7 @@ namespace Vodovoz.ViewModels.ViewModels.Payments
 			{
 				ShowErrorMessage("При сохранении платежа произошла ошибка. Переоткройте диалог.");
 				UoW.Session.Clear();
-				var curPayment = UoW.GetById<Payment>(Entity.Id);
-				curPayment.CurrentEditorUser = null;
-				UoW.Save(curPayment);
-				UoW.Commit();
+				RemoveCurrentEditor(UoW);
 				Close(false, CloseSource.Self);
 			}
 		}
@@ -759,11 +756,17 @@ namespace Vodovoz.ViewModels.ViewModels.Payments
 			{
 				using(var uow = UnitOfWorkFactory.CreateWithoutRoot())
 				{
-					DeleteCurrentEditor();
-					uow.Save(Entity);
-					uow.Commit();
+					RemoveCurrentEditor(uow);
 				}
 			}
+		}
+		
+		private void RemoveCurrentEditor(IUnitOfWork uow)
+		{
+			var curPayment = uow.GetById<Payment>(Entity.Id);
+			curPayment.CurrentEditorUser = null;
+			uow.Save(curPayment);
+			uow.Commit();
 		}
 
 		private ICriterion GetSearchCriterion(params Expression<Func<object>>[] aliasPropertiesExpr) =>

--- a/VodovozViewModels/ViewModels/Payments/ManualPaymentMatchingViewModel.cs
+++ b/VodovozViewModels/ViewModels/Payments/ManualPaymentMatchingViewModel.cs
@@ -513,9 +513,6 @@ namespace Vodovoz.ViewModels.ViewModels.Payments
 			catch
 			{
 				ShowErrorMessage("При сохранении платежа произошла ошибка. Переоткройте диалог.");
-			}
-			finally
-			{
 				UoW.Session.Clear();
 				var curPayment = UoW.GetById<Payment>(Entity.Id);
 				curPayment.CurrentEditorUser = null;


### PR DESCRIPTION
добавил функционал по задаче:
- блокируем открытие диалога распределения конкретного платежа, если кто-то уже с ним работает;
- обновляем список заказов при запуске;
- сделана доработка по авто сопоставлению платежа(дублирующиеся платежи из одной выписки уходят в ручное распределение);