### PR TITLE
Обновление валидации заказа

### DIFF
--- a/VodovozBusiness/Domain/Orders/Order.cs
+++ b/VodovozBusiness/Domain/Orders/Order.cs
@@ -1084,10 +1084,13 @@ namespace Vodovoz.Domain.Orders
 						}
 					}
 
-					if(Client.IsDeliveriesClosed && PaymentType != PaymentType.cash && PaymentType != PaymentType.ByCard)
+					if(Client.IsDeliveriesClosed
+						&& PaymentType != PaymentType.cash
+						&& PaymentType != PaymentType.ByCard
+						&& PaymentType != PaymentType.Terminal)
 						yield return new ValidationResult(
 							"В заказе неверно указан тип оплаты (для данного клиента закрыты поставки)",
-							new[] { this.GetPropertyName(o => o.PaymentType) }
+							new[] { nameof(PaymentType) }
 						);
 
 					//FIXME Исправить изменение данных. В валидации нельзя менять объекты.


### PR DESCRIPTION
Добавляем в исключения Терминал при стоп-отгрузках, чтобы с этим типом оплаты можно было выставлять заказы