### PR TITLE
4112 Фикс переноса нескольких заказов с быстрой доставкой

### DIFF
--- a/Vodovoz/Dialogs/Logistic/RouteListAddressesTransferringDlg.cs
+++ b/Vodovoz/Dialogs/Logistic/RouteListAddressesTransferringDlg.cs
@@ -452,6 +452,8 @@ namespace Vodovoz
 
 				UoW.Save(item);
 				UoW.Save(newItem);
+
+				UoW.Commit();
 			}
 			
 			UpdateTranferDocuments(routeListFrom, routeListTo);


### PR DESCRIPTION
Когда клавишей контрол выбирали несколько адресов и нажимали перенести, запись в базу происходила только после переноса всех адресов, поэтому в цикле остатки после переноса первого заказа через метод репозитория _routeListItemRepository.HasEnoughQuantityForFastDelivery подсчитывались неверно. Это позволяло перенести все выделенные адреса (если хватало остатков на перенос первого адреса), даже если после переноса первого уже нет остатков.