### PR TITLE
Правка св-ва CanGenerate в Аналитике эксплуатации ТС

### DIFF
--- a/VodovozViewModels/ViewModels/Reports/CarsExploitationReportViewModel.cs
+++ b/VodovozViewModels/ViewModels/Reports/CarsExploitationReportViewModel.cs
@@ -40,9 +40,9 @@ namespace Vodovoz.ViewModels.Reports
 
 		private bool _canSave;
 		private bool _isSaving;
-		private bool _canGenerate;
 		private bool _canCancelGenerate;
 		private bool _isGenerating;
+		private IList<Indicator> _selectedIndicators;
 
 		public CarsExploitationReportViewModel(
 			IUnitOfWorkFactory unitOfWorkFactory,
@@ -63,7 +63,6 @@ namespace Vodovoz.ViewModels.Reports
 
 			_canSave = false;
 			_isSaving = false;
-			_canGenerate = true;
 			_canCancelGenerate = false;
 			_isGenerating = false;
 
@@ -95,7 +94,16 @@ namespace Vodovoz.ViewModels.Reports
 		public CarTypeOfUse? TypeOfUse { get; set; }
 		public Car Car { get; set; }
 		public bool ShowCarsWithoutData { get; set; }
-		public IList<Indicator> SelectedIndicators { get; set; }
+		
+		public IList<Indicator> SelectedIndicators 
+		{
+			get => _selectedIndicators;
+			set
+			{
+				SetField(ref _selectedIndicators , value);
+				OnPropertyChanged(nameof(CanGenerate));
+			}
+		}
 
 		#endregion
 
@@ -125,11 +133,7 @@ namespace Vodovoz.ViewModels.Reports
 			}
 		}
 
-		public bool CanGenerate
-		{
-			get => _canGenerate;
-			set => SetField(ref _canGenerate, value);
-		}
+		public bool CanGenerate => !IsGenerating && SelectedIndicators != null && SelectedIndicators.Any();
 
 		public bool CanCancelGenerate
 		{
@@ -143,7 +147,7 @@ namespace Vodovoz.ViewModels.Reports
 			set
 			{
 				SetField(ref _isGenerating, value);
-				CanGenerate = !IsGenerating;
+				OnPropertyChanged(nameof(CanGenerate));
 				CanCancelGenerate = IsGenerating;
 			}
 		}
@@ -156,12 +160,6 @@ namespace Vodovoz.ViewModels.Reports
 
 		public async Task<CarsExploitationReport> ActionGenerateReport(CancellationToken cancellationToken)
 		{
-			if(!SelectedIndicators.Any())
-			{
-				_interactiveService.ShowMessage(ImportanceLevel.Warning, "Не выбрано ни 1 показателя");
-				return null;
-			}
-
 			try
 			{
 				var report = await Generate(StartDate, IndicatorsType, CarOwnType, TypeOfUse, Car, SelectedIndicators, ShowCarsWithoutData, cancellationToken);


### PR DESCRIPTION
CanGenerate отвечает за доступность кнопки генерации отчёта. На неё влияет в том числе выбор показателей. Убрал сообщение, возможность генерации сделал через биндинг.