### PR TITLE
Фикс вставки комментария в заказ из ТД

### DIFF
--- a/Source/Applications/Desktop/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Source/Applications/Desktop/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -2599,6 +2599,8 @@ namespace Vodovoz
 				return;
 			}
 
+			UoW.Session.Refresh(DeliveryPoint);
+
 			AddCommentFromDeliveryPoint();
 			AddCommentLogistFromDeliveryPoint();
 


### PR DESCRIPTION
Если при выборе ТД из заказа в ТД поменять комментарий, то диалог заказа не знал об изменениях в ТД и подставлял старый комментарий.