### PR TITLE
Фикс отображения водителей на карте в мониторинге

### DIFF
--- a/Source/Applications/Desktop/Vodovoz/Dialogs/Logistic/RouteListTrackDlg.cs
+++ b/Source/Applications/Desktop/Vodovoz/Dialogs/Logistic/RouteListTrackDlg.cs
@@ -255,7 +255,7 @@ namespace Vodovoz
 				foreach(var pointsForDriver in lastPoints.GroupBy(x => x.DriverId)) {
 					var lastPoint = pointsForDriver.OrderBy(x => x.Time).Last();
 					var driverRow = (yTreeViewDrivers.RepresentationModel.ItemsList as IList<WorkingDriverVMNode>)
-								.First(x => x.Id == lastPoint.DriverId);
+						.First(x => x.Id == lastPoint.DriverId);
 
 					CarMarkerType iconType;
 					var ere20 = ere20Minuts.Where(x => x.DriverId == pointsForDriver.Key).OrderBy(x => x.Time).LastOrDefault();

--- a/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Logistic/TrackRepository.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Logistic/TrackRepository.cs
@@ -38,6 +38,7 @@ namespace Vodovoz.EntityRepositories.Logistic
 			Track trackAlias = null;
 			TrackPoint subPoint = null;
 			DriverPosition result = null;
+			RouteList routeListsAlias = null;
 
 			var lastTimeTrackQuery = QueryOver.Of<TrackPoint>(() => subPoint)
 				.Where(() => subPoint.Track.Id == trackAlias.Id);
@@ -51,10 +52,11 @@ namespace Vodovoz.EntityRepositories.Logistic
 
 			return uow.Session.QueryOver<TrackPoint>()
 				.JoinAlias(p => p.Track, () => trackAlias)
+				.JoinAlias(() => trackAlias.RouteList, () => routeListsAlias)
 				.Where(() => trackAlias.RouteList.Id.IsIn(routeListsIds))
 				.WithSubquery.WhereProperty(p => p.TimeStamp).Eq(lastTimeTrackQuery)
 				.SelectList(list => list
-					.Select(() => trackAlias.Driver.Id).WithAlias(() => result.DriverId)
+					.Select(() => routeListsAlias.Driver.Id).WithAlias(() => result.DriverId)
 					.Select(() => trackAlias.RouteList.Id).WithAlias(() => result.RouteListId)
 					.Select(x => x.TimeStamp).WithAlias(() => result.Time)
 					.Select(x => x.Latitude).WithAlias(() => result.Latitude)


### PR DESCRIPTION
Когда у МЛ менялся водитель, а в треках сохранён старый водитель, то в мониторинге на таком водителе возникало исключение, и остальные авто не прорисовывались на карте.