### PR TITLE
Reconnect observable list to objects

### DIFF
--- a/Source/Libraries/Core/Business/VodovozBusiness/Domain/Orders/Order.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Domain/Orders/Order.cs
@@ -873,15 +873,10 @@ namespace Vodovoz.Domain.Orders
 			set => SetField(ref orderDocuments, value, () => OrderDocuments);
 		}
 
-		GenericObservableList<OrderDocument> observableOrderDocuments;
+		GenericObservableList<OrderDocument> _observableOrderDocuments;
 		//FIXME Кослыль пока не разберемся как научить hibernate работать с обновляемыми списками.
-		public virtual GenericObservableList<OrderDocument> ObservableOrderDocuments {
-			get {
-				if(observableOrderDocuments == null)
-					observableOrderDocuments = new GenericObservableList<OrderDocument>(OrderDocuments);
-				return observableOrderDocuments;
-			}
-		}
+		public virtual GenericObservableList<OrderDocument> ObservableOrderDocuments => 
+			_observableOrderDocuments?.ReconnectToObject(OrderDocuments) ?? (_observableOrderDocuments = new GenericObservableList<OrderDocument>(OrderDocuments));
 
 		IList<OrderItem> orderItems = new List<OrderItem>();
 


### PR DESCRIPTION
При вызове UoW.Session.Refresh(Entity) теряется связь у дочерних для Entity observable list-ах с изначальными списками. Если после вызова UoW.Session.Refresh(Entity) изменить содержимое в дочернем observable list-е, то изменения в изначальном присоединённом списке не будут отслеживаться NHibernat-ом и не запишутся в базу.