### PR TITLE
Hotfix Проверка позиции заказа на перенос при удалении

### DIFF
--- a/Source/Applications/Desktop/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Source/Applications/Desktop/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -2503,6 +2503,14 @@ namespace Vodovoz
 				}
 			}
 
+			var isMovedToNewOrder = _orderRepository.IsMovedToTheNewOrder(UoW, item);
+			if(isMovedToNewOrder)
+			{
+				MessageDialogHelper.RunWarningDialog(
+					$"Нельзя удалить строку заказа, т.к. данная позиция была перенесена в другой заказ.");
+				return;
+			}
+
 			Entity.RemoveItem(item);
 		}
 

--- a/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
@@ -94,8 +94,8 @@ namespace Vodovoz.EntityRepositories.Orders
 
 		Order GetOrderOnDateAndDeliveryPoint(IUnitOfWork uow, DateTime date, DeliveryPoint deliveryPoint);
 		IList<Order> GetSameOrderForDateAndDeliveryPoint(IUnitOfWorkFactory uow, DateTime date, DeliveryPoint deliveryPoint);
-        Order GetOrder(IUnitOfWork unitOfWork, int orderId);
-        IList<Order> GetOrdersBetweenDates(IUnitOfWork UoW, DateTime startDate, DateTime endDate);
+		Order GetOrder(IUnitOfWork unitOfWork, int orderId);
+		IList<Order> GetOrdersBetweenDates(IUnitOfWork UoW, DateTime startDate, DateTime endDate);
 
 		IList<Order> GetOrdersByCode1c(IUnitOfWork uow, string[] codes1c);
 
@@ -137,6 +137,15 @@ namespace Vodovoz.EntityRepositories.Orders
 		bool OrderHasSentReceipt(IUnitOfWork uow, int orderId);
 		IEnumerable<Order> GetOrders(IUnitOfWork uow, int[] ids);
 		bool HasFlyersOnStock(IUnitOfWork uow, IRouteListParametersProvider routeListParametersProvider, int flyerId, int geographicGroup);
+
+		/// <summary>
+		/// Проверка на перенос данной позиция в другой заказ
+		/// </summary>
+		/// <param name="uow">UnitOfWork</param>
+		/// <param name="orderItem">Позиция заказа</param>
+		/// <returns>true - если свойство CopiedFromUndelivery другого заказа содержит значения, равное Id данной позиции</returns>
+		bool IsMovedToTheNewOrder(IUnitOfWork uow, OrderItem orderItem);
+
 		int? GetMaxOrderDailyNumberForDate(IUnitOfWorkFactory uowFactory, DateTime deliveryDate);
 		DateTime? GetOrderDeliveryDate(IUnitOfWorkFactory uowFactory, int orderId);
 		IList<NotFullyPaidOrderNode> GetAllNotFullyPaidOrdersByClientAndOrg(

--- a/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Orders/OrderRepository.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Orders/OrderRepository.cs
@@ -767,6 +767,15 @@ namespace Vodovoz.EntityRepositories.Orders
 			return subqueryAdded - subqueryRemoved - subqueryReserved > 0;
 		}
 
+		public bool IsMovedToTheNewOrder(IUnitOfWork uow, OrderItem orderItem)
+		{
+			var movedOrderItems = uow.Session.QueryOver<OrderItem>()
+				.Where(o => o.CopiedFromUndelivery.Id == orderItem.Id && o.Id != orderItem.Id)
+				.List<OrderItem>();
+
+			return movedOrderItems.Count > 0;
+		}
+
 		public IEnumerable<VodovozOrder> GetOrders(IUnitOfWork uow, int[] ids)
 		{
 			VodovozOrder vodovozOrderAlias = null;


### PR DESCRIPTION
Если попытаться удалить строки заказа, который был перенесен в новый заказ, то возникает ошибка:
"Cannot delete or update a parent row: a foreign key constraint fails (`Vodovoz_dev_semen`.`order_items`, CONSTRAINT `fk_copied_from_undelivery_ordr_items` FOREIGN KEY (`copied_from_undelivery_id`) REFERENCES `order_items` (`id`) ON UPDATE CASCADE)"

Внесены изменения, чтобы перед удалением проверялось наличия ссылок на данную позицию в copied_from_undelivery_id других позиций и отображалось сообщение о невозможности удаления позиции, а не системная ошибка.