### PR TITLE
4329 - Предупреждение о неверной форме оплаты

### DIFF
--- a/Source/Applications/Desktop/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Source/Applications/Desktop/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -3821,6 +3821,13 @@ namespace Vodovoz
 				return;
 			}
 
+			if(Entity.Client.PaymentMethod != Entity.PaymentType
+				&& !MessageDialogHelper.RunQuestionDialog($"Вы выбрали форму оплаты <{Entity.PaymentType.GetEnumTitle()}>." +
+				$" У клиента по умолчанию установлено <{Entity.Client.PaymentMethod.GetEnumTitle()}>. Вы уверены, что хотите продолжить?"))
+			{
+				return;
+			}
+
 			_summaryInfoBuilder.Clear();
 
 			var clientFIO = Entity.Client.FullName.ToUpper();

--- a/Source/Applications/Desktop/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Source/Applications/Desktop/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -487,7 +487,7 @@ namespace Vodovoz
 					x => x.Client,
 					x => x.DeliveryPoint,
 					x => x.OrderAddressType,
-					x => x.PaymentType,
+					x => x.Client.PaymentMethod,
 					x => x.ContactPhone
 				)
 				.CopyPromotionalSets()
@@ -3822,8 +3822,8 @@ namespace Vodovoz
 			}
 
 			if(Entity.Client.PaymentMethod != Entity.PaymentType
-				&& !MessageDialogHelper.RunQuestionDialog($"Вы выбрали форму оплаты <{Entity.PaymentType.GetEnumTitle()}>." +
-				$" У клиента по умолчанию установлено <{Entity.Client.PaymentMethod.GetEnumTitle()}>. Вы уверены, что хотите продолжить?"))
+				&& !MessageDialogHelper.RunQuestionDialog($"Вы выбрали форму оплаты &lt;{Entity.PaymentType.GetEnumTitle()}&gt;." +
+				$" У клиента по умолчанию установлено &lt;{Entity.Client.PaymentMethod.GetEnumTitle()}&gt;. Вы уверены, что хотите продолжить?"))
 			{
 				return;
 			}

--- a/Source/Applications/Desktop/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Source/Applications/Desktop/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -486,15 +486,19 @@ namespace Vodovoz
 				.CopyFields(
 					x => x.Client,
 					x => x.DeliveryPoint,
+					x => x.PaymentType,
 					x => x.OrderAddressType,
-					x => x.Client.PaymentMethod,
-					x => x.ContactPhone
-				)
+					x => x.ContactPhone)
 				.CopyPromotionalSets()
 				.CopyOrderItems()
 				.CopyAdditionalOrderEquipments()
 				.CopyOrderDepositItems()
 				.CopyAttachedDocuments();
+
+			if(Entity.Client.PersonType == PersonType.legal)
+			{
+				Entity.PaymentType = Entity.Client.PaymentMethod;
+			}
 
 			Entity.UpdateDocuments();
 			CheckForStopDelivery();

--- a/Source/Libraries/Core/Business/VodovozBusiness/Models/Orders/CopyingOrder.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Models/Orders/CopyingOrder.cs
@@ -65,7 +65,7 @@ namespace Vodovoz.Models.Orders
 				_resultOrder.Client = _copiedOrder.Client;
 				_resultOrder.SelfDelivery = _copiedOrder.SelfDelivery;
 				_resultOrder.DeliveryPoint = _copiedOrder.DeliveryPoint;
-				_resultOrder.PaymentType = _copiedOrder.Client.PaymentMethod;
+				_resultOrder.PaymentType = _copiedOrder.PaymentType;
 				_resultOrder.Author = _copiedOrder.Author;
 				_resultOrder.Comment = _copiedOrder.Comment;
 				_resultOrder.CommentLogist = _copiedOrder.CommentLogist;

--- a/Source/Libraries/Core/Business/VodovozBusiness/Models/Orders/CopyingOrder.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Models/Orders/CopyingOrder.cs
@@ -65,7 +65,7 @@ namespace Vodovoz.Models.Orders
 				_resultOrder.Client = _copiedOrder.Client;
 				_resultOrder.SelfDelivery = _copiedOrder.SelfDelivery;
 				_resultOrder.DeliveryPoint = _copiedOrder.DeliveryPoint;
-				_resultOrder.PaymentType = _copiedOrder.PaymentType;
+				_resultOrder.PaymentType = _copiedOrder.Client.PaymentMethod;
 				_resultOrder.Author = _copiedOrder.Author;
 				_resultOrder.Comment = _copiedOrder.Comment;
 				_resultOrder.CommentLogist = _copiedOrder.CommentLogist;


### PR DESCRIPTION
1. В диалоге резюмирования заказа теперь появляется предупреждающее сообщение в случаях когда в карточке контрагента установлена форма оплаты по умолчанию и в заказе она отличная
Текст предупреждения: "Вы выбрали форму оплаты <...>. У клиента по умолчанию установлено <...>. Вы уверены, что хотите продолжить?"
2. Если у клиента установлена форма оплаты по умолчанию, то при копировании заказа подставляется форма оплаты, как в карточке контрагента