### PR TITLE
переделал доступность виновных в недовозах

### DIFF
--- a/Source/Applications/Desktop/Vodovoz/ViewWidgets/UndeliveredOrderView.cs
+++ b/Source/Applications/Desktop/Vodovoz/ViewWidgets/UndeliveredOrderView.cs
@@ -282,10 +282,6 @@ namespace Vodovoz.ViewWidgets
 				&& _undelivery.OldOrder != null
 			);
 
-			guiltyInUndeliveryView.Sensitive = _undelivery.UndeliveryStatus != UndeliveryStatus.Closed
-				&& (ServicesConfig.CommonServices.CurrentPermissionService.ValidatePresetPermission("can_edit_guilty_in_undeliveries") || _undelivery.Id == 0)
-				;
-
 			//кнопки для выбора/создания нового заказа и группа "В работе у отдела"
 			//доступны всегда, если статус недовоза не "Закрыт"
 			hbxInProcessAtDepartment.Sensitive =


### PR DESCRIPTION
при изменении цвета/стиля/размерности шрифта и выставлении sensitive в false, надписи пропадают из treeview, поэтому я сделал ее доступной но заблочил остальные элементы