### PR TITLE
4363 Санобработка в журнале заказов

### DIFF
--- a/Source/Applications/Desktop/Vodovoz/JournalViewModels/OrderForRouteListJournalViewModel.cs
+++ b/Source/Applications/Desktop/Vodovoz/JournalViewModels/OrderForRouteListJournalViewModel.cs
@@ -31,7 +31,7 @@ using Vodovoz.Services;
 
 namespace Vodovoz.JournalViewModels
 {
-    public class OrderForRouteListJournalViewModel : FilterableSingleEntityJournalViewModelBase<VodovozOrder, OrderDlg, OrderForRouteListJournalNode, OrderJournalFilterViewModel>
+	public class OrderForRouteListJournalViewModel : FilterableSingleEntityJournalViewModelBase<VodovozOrder, OrderDlg, OrderForRouteListJournalNode, OrderJournalFilterViewModel>
 	{
 		private readonly IOrderSelectorFactory _orderSelectorFactory;
 		private readonly IEmployeeJournalFactory _employeeJournalFactory;
@@ -108,7 +108,7 @@ namespace Vodovoz.JournalViewModels
 			Employee lastEditorAlias = null;
 			District districtAlias = null;
 
-			Nomenclature sanitizationNomenclature =
+			var sanitizationNomenclatureIds = 
 				new NomenclatureParametersProvider(new ParametersProvider()).GetSanitisationNomenclature(uow);
 
 			var query = uow.Session.QueryOver<VodovozOrder>(() => orderAlias);
@@ -205,7 +205,7 @@ namespace Vodovoz.JournalViewModels
 
 			var sanitisationCountSubquery = QueryOver.Of<OrderItem>(() => orderItemAlias)
 													 .Where(() => orderAlias.Id == orderItemAlias.Order.Id)
-													 .Where(() => orderItemAlias.Nomenclature.Id == sanitizationNomenclature.Id)
+													 .Where(Restrictions.In(Projections.Property(() => orderItemAlias.Nomenclature.Id), sanitizationNomenclatureIds))
 													 .Select(Projections.Sum(() => orderItemAlias.Count));
 
 			var orderSumSubquery = QueryOver.Of<OrderItem>(() => orderItemAlias)

--- a/Source/Applications/Desktop/Vodovoz/JournalViewModels/RetailOrderJournalViewModel.cs
+++ b/Source/Applications/Desktop/Vodovoz/JournalViewModels/RetailOrderJournalViewModel.cs
@@ -196,7 +196,7 @@ namespace Vodovoz.JournalViewModels
 			District districtAlias = null;
 			CounterpartyContract contractAlias = null;
 
-			Nomenclature sanitizationNomenclature = _nomenclatureRepository.GetSanitisationNomenclature(uow);
+			var sanitizationNomenclatureIds = _nomenclatureRepository.GetSanitisationNomenclature(uow);
 
 			var query = uow.Session.QueryOver<VodovozOrder>(() => orderAlias);
 
@@ -333,7 +333,7 @@ namespace Vodovoz.JournalViewModels
 
 			var sanitisationCountSubquery = QueryOver.Of<OrderItem>(() => orderItemAlias)
 													 .Where(() => orderAlias.Id == orderItemAlias.Order.Id)
-													 .Where(() => orderItemAlias.Nomenclature.Id == sanitizationNomenclature.Id)
+													 .Where(Restrictions.In(Projections.Property(() => orderItemAlias.Nomenclature.Id), sanitizationNomenclatureIds))
 													 .Select(Projections.Sum(() => orderItemAlias.Count));
 
 			var orderSumSubquery = QueryOver.Of<OrderItem>(() => orderItemAlias)

--- a/Source/Applications/Desktop/VodovozViewModels/Journals/JournalViewModels/Orders/OrderJournalViewModel.cs
+++ b/Source/Applications/Desktop/VodovozViewModels/Journals/JournalViewModels/Orders/OrderJournalViewModel.cs
@@ -152,7 +152,7 @@ namespace Vodovoz.JournalViewModels
 		}
 
 		protected override void CreateNodeActions()
-        {
+		{
 			NodeActionsList.Clear();
 			CreateDefaultSelectAction();
 			CreateDefaultAddActions();
@@ -161,7 +161,7 @@ namespace Vodovoz.JournalViewModels
 		}
 
 		private void CreateCustomEditAction()
-        {
+		{
 			var editAction = new JournalAction("Изменить",
 				(selected) => {
 					var selectedNodes = selected.OfType<OrderJournalNode>();
@@ -180,9 +180,9 @@ namespace Vodovoz.JournalViewModels
 				(selected) => selected.All(x => (x as OrderJournalNode).Sensitive),
 				(selected) => {
 					if(!selected.All(x => (x as OrderJournalNode).Sensitive))
-                    {
+					{
 						return;
-                    }
+					}
 					var selectedNodes = selected.OfType<OrderJournalNode>();
 					if (selectedNodes == null || selectedNodes.Count() != 1)
 					{
@@ -226,7 +226,7 @@ namespace Vodovoz.JournalViewModels
 			PaymentFrom paymentFromAlias = null;
 			GeoGroup geographicalGroupAlias = null;
 
-			Nomenclature sanitizationNomenclature = _nomenclatureRepository.GetSanitisationNomenclature(uow);
+			var sanitizationNomenclatureIds = _nomenclatureRepository.GetSanitisationNomenclature(uow);
 
 			var query = uow.Session.QueryOver<VodovozOrder>(() => orderAlias)
 				.Left.JoinAlias(o => o.DeliveryPoint, () => deliveryPointAlias)
@@ -423,7 +423,7 @@ namespace Vodovoz.JournalViewModels
 
 			var sanitisationCountSubquery = QueryOver.Of<OrderItem>(() => orderItemAlias)
 													 .Where(() => orderAlias.Id == orderItemAlias.Order.Id)
-													 .Where(() => orderItemAlias.Nomenclature.Id == sanitizationNomenclature.Id)
+													 .Where(Restrictions.In(Projections.Property(() => orderItemAlias.Nomenclature.Id), sanitizationNomenclatureIds))
 													 .Select(Projections.Sum(() => orderItemAlias.Count));
 
 			var orderSumSubquery = QueryOver.Of<OrderItem>(() => orderItemAlias)
@@ -682,17 +682,17 @@ namespace Vodovoz.JournalViewModels
 				.Left.JoinAlias(o => o.Author, () => authorAlias);
 
 			if (FilterViewModel.ViewTypes != ViewTypes.OrderWSFP && FilterViewModel.ViewTypes != ViewTypes.All
-			    || FilterViewModel.RestrictStatus != null && FilterViewModel.RestrictStatus != OrderStatus.Closed
-			    || FilterViewModel.RestrictPaymentType != null
-			    || FilterViewModel.DeliveryPoint != null
+				|| FilterViewModel.RestrictStatus != null && FilterViewModel.RestrictStatus != OrderStatus.Closed
+				|| FilterViewModel.RestrictPaymentType != null
+				|| FilterViewModel.DeliveryPoint != null
 				|| FilterViewModel.OnlineOrderId != null
 				|| FilterViewModel.RestrictOnlyService != null
 				|| FilterViewModel.RestrictOnlySelfDelivery != null
-			    || FilterViewModel.RestrictLessThreeHours == true
-			    || FilterViewModel.OrderPaymentStatus != null
-			    || FilterViewModel.Organisation != null
-			    || FilterViewModel.PaymentByCardFrom != null
-			    || FilterViewModel.SortDeliveryDate == true
+				|| FilterViewModel.RestrictLessThreeHours == true
+				|| FilterViewModel.OrderPaymentStatus != null
+				|| FilterViewModel.Organisation != null
+				|| FilterViewModel.PaymentByCardFrom != null
+				|| FilterViewModel.SortDeliveryDate == true
 				|| !string.IsNullOrWhiteSpace(FilterViewModel.DeliveryPointAddressLike)
 				|| FilterViewModel.ExcludeClosingDocumentDeliverySchedule)
 			{
@@ -855,17 +855,17 @@ namespace Vodovoz.JournalViewModels
 				.Left.JoinAlias(o => o.Author, () => authorAlias);
 
 			if (FilterViewModel.ViewTypes != ViewTypes.OrderWSFAP && FilterViewModel.ViewTypes != ViewTypes.All
-			    || FilterViewModel.RestrictStatus != null && FilterViewModel.RestrictStatus != OrderStatus.Closed
-			    || FilterViewModel.RestrictPaymentType != null
-			    || FilterViewModel.DeliveryPoint != null
+				|| FilterViewModel.RestrictStatus != null && FilterViewModel.RestrictStatus != OrderStatus.Closed
+				|| FilterViewModel.RestrictPaymentType != null
+				|| FilterViewModel.DeliveryPoint != null
 				|| FilterViewModel.OnlineOrderId != null
 				|| FilterViewModel.RestrictOnlyService != null
-			    || FilterViewModel.RestrictOnlySelfDelivery != null
-			    || FilterViewModel.RestrictLessThreeHours == true
-			    || FilterViewModel.OrderPaymentStatus != null
-			    || FilterViewModel.Organisation != null
-			    || FilterViewModel.PaymentByCardFrom != null
-			    || FilterViewModel.SortDeliveryDate == true
+				|| FilterViewModel.RestrictOnlySelfDelivery != null
+				|| FilterViewModel.RestrictLessThreeHours == true
+				|| FilterViewModel.OrderPaymentStatus != null
+				|| FilterViewModel.Organisation != null
+				|| FilterViewModel.PaymentByCardFrom != null
+				|| FilterViewModel.SortDeliveryDate == true
 				|| !string.IsNullOrWhiteSpace(FilterViewModel.DeliveryPointAddressLike)
 				|| FilterViewModel.ExcludeClosingDocumentDeliverySchedule)
 			{
@@ -1064,7 +1064,7 @@ namespace Vodovoz.JournalViewModels
 					"Перейти в недовоз",
 					(selectedItems) => selectedItems.Any(
 						o => _undeliveredOrdersRepository.GetListOfUndeliveriesForOrder(UoW, (o as OrderJournalNode).Id).Any()) 
-					        && IsOrder(GetSelectedNode(selectedItems))
+							&& IsOrder(GetSelectedNode(selectedItems))
 							&& !_userHasOnlyAccessToWarehouseAndComplaints,
 					selectedItems => selectedItems.All(x => (x as OrderJournalNode).Sensitive),
 					(selectedItems) => {

--- a/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Goods/INomenclatureRepository.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Goods/INomenclatureRepository.cs
@@ -39,7 +39,7 @@ namespace Vodovoz.EntityRepositories.Goods
 		QueryOver<Nomenclature> NomenclatureInGroupsQuery(int[] groupsIds);
 		Nomenclature GetNomenclatureToAddWithMaster(IUnitOfWork uow);
 		Nomenclature GetForfeitNomenclature(IUnitOfWork uow);
-		Nomenclature GetSanitisationNomenclature(IUnitOfWork uow);
+		int[] GetSanitisationNomenclature(IUnitOfWork uow);
 
 		#region Rent
 

--- a/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Goods/NomenclatureRepository.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Goods/NomenclatureRepository.cs
@@ -160,7 +160,7 @@ namespace Vodovoz.EntityRepositories.Goods
 		
 		public Nomenclature GetForfeitNomenclature(IUnitOfWork uow) => nomenclatureParametersProvider.GetForfeitNomenclature(uow);
 		
-		public Nomenclature GetSanitisationNomenclature(IUnitOfWork uow) => nomenclatureParametersProvider.GetSanitisationNomenclature(uow);
+		public int[] GetSanitisationNomenclature(IUnitOfWork uow) => nomenclatureParametersProvider.GetSanitisationNomenclature(uow);
 		
 		public IList<Nomenclature> GetNomenclatureWithPriceForMobileApp(IUnitOfWork uow, params MobileCatalog[] catalogs)
 		{

--- a/Source/Libraries/Core/Business/VodovozBusiness/Parameters/NomenclatureParametersProvider.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Parameters/NomenclatureParametersProvider.cs
@@ -1,36 +1,37 @@
 ﻿using System;
+using System.Linq;
 using QS.DomainModel.UoW;
 using Vodovoz.Domain.Goods;
 using Vodovoz.Services;
 
 namespace Vodovoz.Parameters
 {
-    public class NomenclatureParametersProvider : INomenclatureParametersProvider
-    {
-        private readonly IParametersProvider _parametersProvider;
+	public class NomenclatureParametersProvider : INomenclatureParametersProvider
+	{
+		private readonly IParametersProvider _parametersProvider;
 
 		public NomenclatureParametersProvider(IParametersProvider parametersProvider)
-        {
-            _parametersProvider = parametersProvider ?? throw new ArgumentNullException(nameof(parametersProvider));
-        }
-        
-        #region INomenclatureParametersProvider implementation
+		{
+			_parametersProvider = parametersProvider ?? throw new ArgumentNullException(nameof(parametersProvider));
+		}
+		
+		#region INomenclatureParametersProvider implementation
 
-        public int Folder1cForOnlineStoreNomenclatures => _parametersProvider.GetIntValue("folder_1c_for_online_store_nomenclatures");
+		public int Folder1cForOnlineStoreNomenclatures => _parametersProvider.GetIntValue("folder_1c_for_online_store_nomenclatures");
 
 		public int PaidDeliveryNomenclatureId => _parametersProvider.GetIntValue("paid_delivery_nomenclature_id");
 
 		public int MeasurementUnitForOnlineStoreNomenclatures => _parametersProvider.GetIntValue("measurement_unit_for_online_store_nomenclatures");
 
-        public int RootProductGroupForOnlineStoreNomenclatures => _parametersProvider.GetIntValue("root_product_group_for_online_store_nomenclatures");
+		public int RootProductGroupForOnlineStoreNomenclatures => _parametersProvider.GetIntValue("root_product_group_for_online_store_nomenclatures");
 
-        public int CurrentOnlineStoreId => _parametersProvider.GetIntValue("current_online_store_id");
+		public int CurrentOnlineStoreId => _parametersProvider.GetIntValue("current_online_store_id");
 
-        public decimal GetWaterPriceIncrement => _parametersProvider.GetDecimalValue("water_price_increment");
+		public decimal GetWaterPriceIncrement => _parametersProvider.GetDecimalValue("water_price_increment");
 
-        public string OnlineStoreExportFileUrl => _parametersProvider.GetStringValue("online_store_export_file_url");
+		public string OnlineStoreExportFileUrl => _parametersProvider.GetStringValue("online_store_export_file_url");
 
-        public int FastDeliveryNomenclatureId => _parametersProvider.GetIntValue("fast_delivery_nomenclature_id");
+		public int FastDeliveryNomenclatureId => _parametersProvider.GetIntValue("fast_delivery_nomenclature_id");
 
 		public int PromotionalNomenclatureGroupId => _parametersProvider.GetIntValue("promotional_nomenclature_group_id");
 
@@ -94,10 +95,16 @@ namespace Vodovoz.Parameters
 			return uow.GetById<Nomenclature>(id);
 		}
 		
-		public Nomenclature GetSanitisationNomenclature(IUnitOfWork uow)
+		public int[] GetSanitisationNomenclature(IUnitOfWork uow)
 		{
-			var id = _parametersProvider.GetIntValue("выезд_мастера_для_сан_обр");
-			return uow.GetById<Nomenclature>(id);
+			var ids = _parametersProvider.GetStringValue("выезд_мастера_для_сан_обр");
+			
+			var splitedIds = ids
+				.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries)
+				.Select(x => int.Parse(x))
+				.ToArray();
+			
+			return splitedIds;
 		}
 		
 		public Nomenclature GetForfeitNomenclature(IUnitOfWork uow)

--- a/Source/Libraries/Core/Business/VodovozBusiness/Services/INomenclatureParametersProvider.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Services/INomenclatureParametersProvider.cs
@@ -3,32 +3,32 @@ using Vodovoz.Domain.Goods;
 
 namespace Vodovoz.Services
 {
-    public interface INomenclatureParametersProvider
-    {
-	    int PaidDeliveryNomenclatureId { get; }
+	public interface INomenclatureParametersProvider
+	{
+		int PaidDeliveryNomenclatureId { get; }
 		int Folder1cForOnlineStoreNomenclatures { get; }
-        int MeasurementUnitForOnlineStoreNomenclatures { get; }
-        int RootProductGroupForOnlineStoreNomenclatures { get; }
-        int CurrentOnlineStoreId { get; }
-        decimal GetWaterPriceIncrement { get; }
-        string OnlineStoreExportFileUrl { get; }
-        int FastDeliveryNomenclatureId { get; }
+		int MeasurementUnitForOnlineStoreNomenclatures { get; }
+		int RootProductGroupForOnlineStoreNomenclatures { get; }
+		int CurrentOnlineStoreId { get; }
+		decimal GetWaterPriceIncrement { get; }
+		string OnlineStoreExportFileUrl { get; }
+		int FastDeliveryNomenclatureId { get; }
 		int PromotionalNomenclatureGroupId { get; }
 		int DailyCoolerRentNomenclatureId { get; }
 		int[] PaidDeliveriesNomenclaturesIds();
 
 		Nomenclature GetWaterSemiozerie(IUnitOfWork uow);
-        Nomenclature GetWaterKislorodnaya(IUnitOfWork uow);
-        Nomenclature GetWaterSnyatogorskaya(IUnitOfWork uow);
-        Nomenclature GetWaterKislorodnayaDeluxe(IUnitOfWork uow);
-        Nomenclature GetWaterStroika(IUnitOfWork uow);
-        Nomenclature GetWaterRuchki(IUnitOfWork uow);
-        Nomenclature GetDefaultBottleNomenclature(IUnitOfWork uow);
-        Nomenclature GetNomenclatureToAddWithMaster(IUnitOfWork uow);
-        Nomenclature GetSanitisationNomenclature(IUnitOfWork uow);
-        Nomenclature GetForfeitNomenclature(IUnitOfWork uow);
+		Nomenclature GetWaterKislorodnaya(IUnitOfWork uow);
+		Nomenclature GetWaterSnyatogorskaya(IUnitOfWork uow);
+		Nomenclature GetWaterKislorodnayaDeluxe(IUnitOfWork uow);
+		Nomenclature GetWaterStroika(IUnitOfWork uow);
+		Nomenclature GetWaterRuchki(IUnitOfWork uow);
+		Nomenclature GetDefaultBottleNomenclature(IUnitOfWork uow);
+		Nomenclature GetNomenclatureToAddWithMaster(IUnitOfWork uow);
+		int[] GetSanitisationNomenclature(IUnitOfWork uow);
+		Nomenclature GetForfeitNomenclature(IUnitOfWork uow);
 
-        int GetIdentifierOfOnlineShopGroup();
+		int GetIdentifierOfOnlineShopGroup();
 		Nomenclature GetFastDeliveryNomenclature(IUnitOfWork uow);
 	}
 }


### PR DESCRIPTION
В данный момент в таблице параметров БД номер номенклатуры выезда мастера для санобработки указан одним числом.
Изменения позволяют ввести несколько id номенклатур выезда мастера в таблице параметров БД через запятую. 
В журналах заказов, присутствующие в заказе номенклатуры выездов мастера будут суммироваться и отображаться в столбце "Кол-во с/о"