### PR TITLE
Фикс копирования строк заказа из панели ТД заказа

### DIFF
--- a/Source/Applications/Desktop/Vodovoz/SidePanel/InfoViews/DeliveryPointPanelView.cs
+++ b/Source/Applications/Desktop/Vodovoz/SidePanel/InfoViews/DeliveryPointPanelView.cs
@@ -229,6 +229,7 @@ namespace Vodovoz.SidePanel.InfoViews
 			{
 				var order = ytreeLastOrders.GetSelectedObject() as Order;
 				orderDlg.FillOrderItems(order);
+				orderDlg.Entity.ObservablePromotionalSets.Clear();
 			}
 		}
 


### PR DESCRIPTION
Т.к. при копировании тмц из панели ТД не копируются промонаборы для каждой тмц, то и для заказа они не нужны.