### PR TITLE
Хотфикс. Изменение статуса заказа после оплаты по SMS QR

### DIFF
--- a/Source/Libraries/Core/Business/VodovozBusiness/Domain/FastPayments/FastPayment.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Domain/FastPayments/FastPayment.cs
@@ -4,6 +4,7 @@ using QS.DomainModel.UoW;
 using QS.HistoryLog;
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using Vodovoz.Domain.Client;
 using Vodovoz.Domain.Orders;
 using Vodovoz.Domain.Organizations;
@@ -166,12 +167,14 @@ namespace Vodovoz.Domain.FastPayments
 		{
 			FastPaymentStatus = FastPaymentStatus.Performed;
 
-			if(Order.PaymentType == PaymentType.Cash
+			var selfDeliveryOrderPaymentTypes = new PaymentType[] { PaymentType.Cash, PaymentType.SmsQR };
+
+			if(selfDeliveryOrderPaymentTypes.Contains(Order.PaymentType)
 				&& Order.SelfDelivery
 				&& Order.OrderStatus == OrderStatus.WaitForPayment
 				&& Order.PayAfterShipment)
 			{
-				Order.TryCloseSelfDeliveryOrder(
+				Order.TryCloseSelfDeliveryPayAfterShipmentOrder(
 					uow,
 					standartNomenclatures,
 					routeListItemRepository,
@@ -180,7 +183,7 @@ namespace Vodovoz.Domain.FastPayments
 				Order.IsSelfDeliveryPaid = true;
 			}
 
-			if(Order.PaymentType == PaymentType.Cash
+			if(selfDeliveryOrderPaymentTypes.Contains(Order.PaymentType)
 				&& Order.SelfDelivery
 				&& Order.OrderStatus == OrderStatus.WaitForPayment
 				&& !Order.PayAfterShipment)

--- a/Source/Libraries/Core/Business/VodovozBusiness/Domain/SmsPayment.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Domain/SmsPayment.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel.DataAnnotations;
 using QS.DomainModel.Entity;
 using QS.DomainModel.UoW;
@@ -94,7 +94,7 @@ namespace Vodovoz.Domain
                 && Order.OrderStatus == OrderStatus.WaitForPayment
                 && Order.PayAfterShipment)
             {
-                Order.TryCloseSelfDeliveryOrder(
+                Order.TryCloseSelfDeliveryPayAfterShipmentOrder(
                     uow,
                     new BaseParametersProvider(new ParametersProvider()),
                     new RouteListItemRepository(),


### PR DESCRIPTION
Исправлены методы отвечающие за изменение статуса заказа с самовывозом
Проблема с изменением статуса заказа с самовывозом с оплатой после отгрузки
Если оплата заказа  была произведена до отпуска самовывоза, заказ после отпуска самовывоза оставался в "Ожидание платежа"
Если оплата была выполнена для заказа в статусе "Ожидание платежа", то он не переходит в статус "Закрыт"