### PR TITLE
правка расчета операции перемещения бутылей

### DIFF
--- a/Source/Libraries/Core/Business/VodovozBusiness/Domain/Orders/Order.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Domain/Orders/Order.cs
@@ -3857,8 +3857,10 @@ namespace Vodovoz.Domain.Orders
 			if(IsContractCloser)
 				return false;
 
-			int amountDelivered = (int)OrderItems.Where(item => item.Nomenclature.Category == NomenclatureCategory.water && !item.Nomenclature.IsDisposableTare)
-								.Sum(item => item?.ActualCount ?? 0);
+			int amountDelivered = (int)OrderItems
+				.Where(item => item.Nomenclature.Category == NomenclatureCategory.water
+					&& item.Nomenclature.TareVolume == TareVolume.Vol19L)
+				.Sum(item => item.ActualCount ?? 0);
 
 			if(forfeitQuantity == null) {
 				forfeitQuantity = (int)OrderItems.Where(i => i.Nomenclature.Id == standartNomenclatures.GetForfeitId())


### PR DESCRIPTION
считаем все 19л бутыли заказа, не смотря на тип тары, т.к. появились 19л в одноразовой таре