### PR TITLE
Хотфикс. Отключение появления окна с ошибкой после падения при подтверждении заказа

### DIFF
--- a/Source/Applications/Desktop/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
+++ b/Source/Applications/Desktop/Vodovoz/Dialogs/OrderWidgets/OrderDlg.cs
@@ -2545,6 +2545,11 @@ namespace Vodovoz
 
 		private void ReturnToNew(IEnumerable<Error> errors)
 		{
+			if(errors.All(x => x == Errors.Orders.Order.AcceptException))
+			{
+				return;
+			}
+
 			if(errors.All(x => x != Errors.Orders.Order.AcceptException))
 			{
 				EditOrder();


### PR DESCRIPTION
Окно с индикацией недружественной ошибки скрывается, т.к при эксепшене при подтверждении заказа уже было показано сообщение с комментарием