### PR TITLE
Хотфикс. Ввод только цифр в поле ИНН фильтра

### DIFF
--- a/Source/Applications/Desktop/Vodovoz/Filters/GtkViews/CounterpartyFilterView.cs
+++ b/Source/Applications/Desktop/Vodovoz/Filters/GtkViews/CounterpartyFilterView.cs
@@ -85,6 +85,7 @@ namespace Vodovoz.Filters.GtkViews
 				.AddBinding(ViewModel, vm => vm.CounterpartyVodovozInternalId, w => w.Text, new NullableIntToStringConverter())
 				.InitializeFromSource();
 
+			entryCounterpartyInn.ValidationMode = ValidationType.Numeric;
 			entryCounterpartyInn.KeyReleaseEvent += OnKeyReleased;
 			entryCounterpartyInn.Binding
 				.AddBinding(ViewModel, vm => vm.CounterpartyInn, w => w.Text)


### PR DESCRIPTION
При поиске по ИНН в журнале КА , если пользователь вставляет ИНН с переносом строки в конце, то контрагент не находится.