### PR TITLE
грузим отдельно операции, а не смотрим в самом МЛ

### DIFF
--- a/Source/Applications/Desktop/VodovozViewModels/Logistic/RouteListJournalViewModel.cs
+++ b/Source/Applications/Desktop/VodovozViewModels/Logistic/RouteListJournalViewModel.cs
@@ -841,7 +841,7 @@ namespace Vodovoz.ViewModels.Logistic
 			{
 				return false;
 			}
-			return !_routeListRepository.RouteListContainsGivedFuelLiters(UoW, selectedNode.Id);
+			return !_routeListRepository.RouteListContainsGivenFuelLiters(UoW, selectedNode.Id);
 		}
 
 		private void SendRouteListsInLoading(IList<RouteListJournalNode> selectedNodes)

--- a/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Logistic/IRouteListRepository.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Logistic/IRouteListRepository.cs
@@ -53,7 +53,7 @@ namespace Vodovoz.EntityRepositories.Logistic
 		/// <param name="routeListId">Идентификатор МЛ</param>
 		/// <returns></returns>
 		bool IsTerminalRequired(IUnitOfWork uow, int routeListId);
-		bool RouteListContainsGivedFuelLiters(IUnitOfWork uow, int id);
+		bool RouteListContainsGivenFuelLiters(IUnitOfWork uow, int routeListId);
 		decimal TerminalTransferedCountToRouteList(IUnitOfWork unitOfWork, RouteList routeList);
 		IList<DocumentPrintHistory> GetPrintsHistory(IUnitOfWork uow, RouteList routeList);
 		IEnumerable<int> GetDriverRouteListsIds(IUnitOfWork uow, Employee driver, RouteListStatus? status = null);

--- a/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Logistic/RouteListRepository.cs
@@ -1121,19 +1121,21 @@ namespace Vodovoz.EntityRepositories.Logistic
 				).TransformUsing(Transformers.AliasToBean<KeyValuePair<string, int>>()).List<KeyValuePair<string, int>>();
 		}
 		
-		public bool RouteListContainsGivedFuelLiters(IUnitOfWork uow, int id)
+		public bool RouteListContainsGivenFuelLiters(IUnitOfWork uow, int routeListId)
 		{
-			bool result = false;
+			var result = false;
 
-			var routeList = uow.Session.QueryOver<RouteList>()
-				.Where(x => x.Id == id)
-				.SingleOrDefault<RouteList>();
+			var fuelOperations = uow.Session.QueryOver<FuelDocument>()
+				.Where(x => x.RouteList.Id == routeListId)
+				.Select(f => f.FuelOperation)
+				.List<FuelOperation>();
 
-			foreach(var fuelDocument in routeList.FuelDocuments)
+			foreach(var operation in fuelOperations)
 			{
-				decimal litersGived = fuelDocument.FuelOperation?.LitersGived ?? default(decimal);
-				decimal payedLiters = fuelDocument.FuelOperation?.PayedLiters ?? default(decimal);
-				if(litersGived > 0 || payedLiters > 0)
+				var litersGiven = operation.LitersGived;
+				var payedLiters = operation.PayedLiters;
+				
+				if(litersGiven > 0 || payedLiters > 0)
 				{
 					result = true;
 				}


### PR DESCRIPTION
если журнал не обновлялся, то данные по МЛ подтянутся из сессии, а не из базы и МЛ будет без документа по топливу