### PR TITLE
Хотфикс - изменение в отчете по простою

### DIFF
--- a/Source/Applications/Desktop/VodovozViewModels/Logistic/Reports/CarIsNotAtLineReport.cs
+++ b/Source/Applications/Desktop/VodovozViewModels/Logistic/Reports/CarIsNotAtLineReport.cs
@@ -89,7 +89,6 @@ namespace Vodovoz.Presentation.ViewModels.Logistic.Reports
 			int carTransferEventTypeId,
 			int carReceptionEventTypeId)
 		{
-			date = date.LatestDayTime();
 			var startDate = date.AddDays(-countDays).Date;
 
 			var cars = (from car in unitOfWork.Session.Query<Car>()
@@ -117,7 +116,7 @@ namespace Vodovoz.Presentation.ViewModels.Logistic.Reports
 				 let lastRouteListDate =
 					(DateTime?)(from routeList in unitOfWork.Session.Query<RouteList>()
 								where routeList.Car.Id == car.Id
-									&& routeList.Date <= date
+									&& routeList.Date <= date.LatestDayTime()
 								orderby routeList.Date descending
 								select routeList.Date)
 					.FirstOrDefault()
@@ -139,8 +138,8 @@ namespace Vodovoz.Presentation.ViewModels.Logistic.Reports
 
 			var events = carEventRepository.Get(
 				unitOfWork,
-				ce => ce.StartDate <= date
-					&& ce.EndDate >= date
+				ce => ce.StartDate <= date.Date
+					&& ce.EndDate >= date.Date
 					&& (!includedEventsIds.Any() || includedEventsIds.Contains(ce.CarEventType.Id))
 					&& (!excludedEventsIds.Any() || !excludedEventsIds.Contains(ce.CarEventType.Id)));
 
@@ -159,7 +158,7 @@ namespace Vodovoz.Presentation.ViewModels.Logistic.Reports
 					&& (!includedEventsIds.Any() || includedEventsIds.Contains(carTransferEventTypeId))
 					&& (!excludedEventsIds.Any() || !excludedEventsIds.Contains(carTransferEventTypeId))
 					&& e.CreateDate >= date.AddDays(-1).Date
-					&& e.CreateDate <= date)
+					&& e.CreateDate <= date.LatestDayTime())
 				.ToArray();
 
 			var filteredRecieveEvents = carEventRepository.Get(
@@ -169,7 +168,7 @@ namespace Vodovoz.Presentation.ViewModels.Logistic.Reports
 					&& (!includedEventsIds.Any() || includedEventsIds.Contains(carReceptionEventTypeId))
 					&& (!excludedEventsIds.Any() || !excludedEventsIds.Contains(carReceptionEventTypeId))
 					&& e.CreateDate >= date.AddDays(-1).Date
-					&& e.CreateDate <= date)
+					&& e.CreateDate <= date.LatestDayTime())
 				.ToArray();
 
 			var rows = new List<Row>();


### PR DESCRIPTION
Исправление даты в выборке
Теперь события, где окончание события >= даты (первого времени дня), указанной как параметр отчета будут попадать в выборку событий