### PR TITLE
оптимизация получения заказов для отправки УПД по ЭДО

### DIFF
--- a/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
@@ -149,7 +149,8 @@ namespace Vodovoz.EntityRepositories.Orders
 		IList<NotFullyPaidOrderNode> GetAllNotFullyPaidOrdersByClientAndOrg(
 			IUnitOfWork uow, int counterpartyId, int organizationId, int closingDocumentDeliveryScheduleId);
 		PaymentType GetCurrentOrderPaymentTypeInDB(IUnitOfWork uow, int orderId);
-		IList<Order> GetCashlessOrdersForEdoSendUpd(IUnitOfWork uow, DateTime startDate, int organizationId, int closingDocumentDeliveryScheduleId);
+		IEnumerable<Order> GetCashlessOrdersForEdoSendUpd(
+			IUnitOfWork uow, DateTime startDate, int organizationId, int closingDocumentDeliveryScheduleId);
 		IList<EdoContainer> GetPreparingToSendEdoContainers(IUnitOfWork uow, DateTime startDate, int organizationId);
 		EdoContainer GetEdoContainerByMainDocumentId(IUnitOfWork uow, string mainDocId);
 		EdoContainer GetEdoContainerByDocFlowId(IUnitOfWork uow, Guid? docFlowId);


### PR DESCRIPTION
разделил запрос на два, сначала получаем все нужные заказы, по которым не было отправки, затем берем те, по которым нужна переотправка и объединяем две полученные коллекции, беря уникальные значения