### PR TITLE
5066 дополнил проверку на халявщиков

### DIFF
--- a/Source/Libraries/Core/Backend/CustomerAppsApi.Library/Models/OrderModel.cs
+++ b/Source/Libraries/Core/Backend/CustomerAppsApi.Library/Models/OrderModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
 using QS.DomainModel.UoW;
+using Vodovoz.Domain.Client;
 using Vodovoz.EntityRepositories.Orders;
 
 namespace CustomerAppsApi.Library.Models
@@ -23,7 +24,9 @@ namespace CustomerAppsApi.Library.Models
 
 		public bool CanCounterpartyOrderPromoSetForNewClients(int counterpartyId)
 		{
-			return !_orderRepository.HasCounterpartyFirstRealOrder(_unitOfWork, counterpartyId);
+			var counterparty = _unitOfWork.GetById<Counterparty>(counterpartyId);
+			
+			return !_orderRepository.HasCounterpartyFirstRealOrder(_unitOfWork, counterparty);
 		}
 	}
 }

--- a/Source/Libraries/Core/Business/Vodovoz.Application/Orders/Services/OrderFromOnlineOrderValidator.cs
+++ b/Source/Libraries/Core/Business/Vodovoz.Application/Orders/Services/OrderFromOnlineOrderValidator.cs
@@ -165,28 +165,20 @@ namespace Vodovoz.Application.Orders.Services
 				return;
 			}
 
-			if(_freeLoaderChecker.CheckFreeLoaderOrderByNaturalClientToOfficeOrStore(
-				uow, _onlineOrder.IsSelfDelivery, _onlineOrder.Counterparty, _onlineOrder.DeliveryPoint))
+			var result = _freeLoaderChecker.CanOrderPromoSetForNewClientsFromOnline(
+				uow,
+				_onlineOrder.IsSelfDelivery,
+				_onlineOrder.CounterpartyId,
+				_onlineOrder.DeliveryPointId);
+
+			if(result.IsSuccess)
 			{
-				errors.Add(Vodovoz.Errors.Orders.Order.UnableToShipPromoSet);
 				return;
 			}
 
-			var phones = new List<Phone>();
-
-			if(_onlineOrder.Counterparty != null)
+			foreach(var error in result.Errors)
 			{
-				phones.AddRange(_onlineOrder.Counterparty.Phones);
-			}
-
-			if(_onlineOrder.DeliveryPoint != null)
-			{
-				phones.AddRange(_onlineOrder.DeliveryPoint.Phones);
-			}
-
-			if(_freeLoaderChecker.CheckFreeLoaders(uow, 0, _onlineOrder.DeliveryPoint, phones))
-			{
-				errors.Add(Vodovoz.Errors.Orders.Order.UnableToShipPromoSet);
+				errors.Add(error);
 			}
 		}
 

--- a/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Orders/IFreeLoaderRepository.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Orders/IFreeLoaderRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using QS.DomainModel.UoW;
 using Vodovoz.Domain.Client;
 using Vodovoz.Domain.Contacts;
@@ -8,19 +9,58 @@ namespace VodovozBusiness.EntityRepositories.Orders
 {
 	public interface IFreeLoaderRepository
 	{
+		/// <summary>
+		/// Выборка информации о заказах с промонаборами, которые заказывались на такой же адрес
+		/// сравнение по строковым значениям города, улицы, дома и квартиры
+		/// Если найдется хоть одно совпадение, значит клиент может являться халявщиком
+		/// </summary>
+		/// <param name="uow">unit of work</param>
+		/// <param name="orderId">Номер текущего заказа для исключения из выборки</param>
+		/// <param name="deliveryPoint">Точка доставки</param>
+		/// <returns>Набор данных о ранних заказах промиков на аналогичный адрес <see cref="FreeLoaderInfoNode"/></returns>
 		IEnumerable<FreeLoaderInfoNode> GetPossibleFreeLoadersByAddress(
 			IUnitOfWork uow,
 			int orderId,
 			DeliveryPoint deliveryPoint);
 
+		/// <summary>
+		/// Выборка информации о заказах с промонаборами, которые заказывались на такой же телефон
+		/// сравнение по номерам телефонов клиента
+		/// Если найдется хоть одно совпадение, значит клиент может являться халявщиком
+		/// </summary>
+		/// <param name="uow">unit of work</param>
+		/// <param name="orderId">Номер текущего заказа для исключения из выборки</param>
+		/// <param name="phones">Список телефонов для поиска</param>
+		/// <returns>Набор данных о ранних заказах промиков по указанным телефонам <see cref="FreeLoaderInfoNode"/></returns>
 		IEnumerable<FreeLoaderInfoNode> GetPossibleFreeLoadersInfoByCounterpartyPhones(
 			IUnitOfWork uow,
 			int orderId,
 			IEnumerable<Phone> phones);
 
+		/// <summary>
+		/// Выборка информации о заказах с промонаборами, которые заказывались на такой же телефон
+		/// сравнение по номерам телефонов точки доставки
+		/// Если найдется хоть одно совпадение, значит клиент может являться халявщиком
+		/// </summary>
+		/// <param name="uow">unit of work</param>
+		/// <param name="excludeOrderIds">Номера исключаемых заказов</param>
+		/// <param name="phones">Список телефонов для поиска</param>
+		/// <returns>Набор данных о ранних заказах промиков по указанным телефонам <see cref="FreeLoaderInfoNode"/></returns>
 		IEnumerable<FreeLoaderInfoNode> GetPossibleFreeLoadersInfoByDeliveryPointPhones(
 			IUnitOfWork uow,
 			IEnumerable<int> excludeOrderIds,
 			IEnumerable<Phone> phones);
+		/// <summary>
+		/// Выборка информации о заказах с промонаборами, которые заказывались на такой же адрес(сравнение по Guid дома в ФИАСе) с квартирой
+		/// Если найдется хоть одно совпадение, значит клиент может являться халявщиком
+		/// </summary>
+		/// <param name="uow">unit of work</param>
+		/// <param name="buildingFiasGuid">Guid дома в ФИАСе</param>
+		/// <param name="room">Номер квартиры</param>
+		/// <param name="orderId">Номер текущего заказа для исключения из выборки</param>
+		/// <param name="promoSetForNewClients">Промик для новых клиентов или нет, по умолчанию true</param>
+		/// <returns>Набор данных о ранних заказах промиков на аналогичный адрес <see cref="FreeLoaderInfoNode"/></returns>
+		IEnumerable<FreeLoaderInfoNode> GetPossibleFreeLoadersInfoByBuildingFiasGuid(
+			IUnitOfWork uow, Guid buildingFiasGuid, string room, int orderId, bool promoSetForNewClients = true);
 	}
 }

--- a/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/EntityRepositories/Orders/IOrderRepository.cs
@@ -60,7 +60,7 @@ namespace Vodovoz.EntityRepositories.Orders
 		/// <param name="client">Контрагент</param>
 		Order GetFirstRealOrderForClientForActionBottle(IUnitOfWork uow, Order order, Counterparty client);
 
-		bool HasCounterpartyFirstRealOrder(IUnitOfWork uow, int counterpartyId);
+		bool HasCounterpartyFirstRealOrder(IUnitOfWork uow, Counterparty counterparty);
 		bool HasCounterpartyOtherFirstRealOrder(IUnitOfWork uow, Counterparty counterparty, int orderId);
 
 		OrderStatus[] GetGrantedStatusesToCreateSeveralOrders();

--- a/Source/Libraries/Core/Business/VodovozBusiness/Errors/Orders/Order.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Errors/Orders/Order.cs
@@ -42,7 +42,21 @@
 				typeof(Order),
 				nameof(UnableToShipPromoSet),
 				"По этому адресу/телефону уже была ранее отгрузка промо набора\n" +
-				"Пожалуйста удалите промо набор или поменяйте адрес доставки.");
+				"Пожалуйста, удалите промо набор или поменяйте адрес доставки.");
+		
+		public static Error UnableToShipPromoSetForNewClientsFromSelfDelivery =>
+			new Error(
+				typeof(Order),
+				nameof(UnableToShipPromoSetForNewClientsFromSelfDelivery),
+				"В самовывозе нельзя заказывать промо набор для новых клиентов\n" +
+				"Пожалуйста, удалите промо набор.");
+		
+		public static Error UnableToShipPromoSetForNewClientsToUnknownClientOrDeliveryPoint =>
+			new Error(
+				typeof(Order),
+				nameof(UnableToShipPromoSetForNewClientsToUnknownClientOrDeliveryPoint),
+				"Нельзя заказывать промо набор для новых клиентов для неизвестного клиента или адреса\n" +
+				"Пожалуйста, удалите промо набор или выберите нужного клиента с адресом, по которым не было таких отгрузок.");
 
 		public static Error Save =>
 			new Error(

--- a/Source/Libraries/Core/Business/VodovozBusiness/Services/Orders/IFreeLoaderChecker.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Services/Orders/IFreeLoaderChecker.cs
@@ -2,6 +2,7 @@
 using QS.DomainModel.UoW;
 using Vodovoz.Domain.Client;
 using Vodovoz.Domain.Contacts;
+using Vodovoz.Errors;
 using Vodovoz.Nodes;
 
 namespace VodovozBusiness.Services.Orders
@@ -49,5 +50,20 @@ namespace VodovozBusiness.Services.Orders
 			bool isSelfDelivery,
 			Counterparty client,
 			DeliveryPoint deliveryPoint);
+		/// <summary>
+		/// Проверка на возможного халявщика для ИПЗ(можно ли заказывать промик для нового клиента).
+		/// </summary>
+		/// <param name="uow">unit of work</param>
+		/// <param name="isSelfDelivery">Самовывоз или нет</param>
+		/// <param name="counterpartyId">Id клиента</param>
+		/// <param name="deliveryPointId">Id точки доставки</param>
+		/// <returns>
+		/// <see cref="Result.IsSuccess"/> - может заказывать промик для новых клиентов,
+		/// <see cref="Result.Failure(Vodovoz.Errors.Error)"/> - нет</returns>
+		Result CanOrderPromoSetForNewClientsFromOnline(
+			IUnitOfWork uow,
+			bool isSelfDelivery,
+			int? counterpartyId,
+			int? deliveryPointId);
 	}
 }

--- a/Source/Libraries/Infrastructure/Vodovoz.Infrastructure.Persistance/Orders/OrderRepository.cs
+++ b/Source/Libraries/Infrastructure/Vodovoz.Infrastructure.Persistance/Orders/OrderRepository.cs
@@ -291,10 +291,8 @@ namespace Vodovoz.Infrastructure.Persistance.Orders
 			return query.List().FirstOrDefault();
 		}
 
-		public bool HasCounterpartyFirstRealOrder(IUnitOfWork uow, int counterpartyId)
+		public bool HasCounterpartyFirstRealOrder(IUnitOfWork uow, Counterparty counterparty)
 		{
-			var counterparty = uow.GetById<Counterparty>(counterpartyId);
-
 			if(counterparty is null)
 			{
 				return false;


### PR DESCRIPTION
- исключаем возможность автоматического заказа промиков для новых клиентов в самовывозе из онлайна;
- в первую очередь проверяем халявщика по Guid ФИАСа, если он есть, только потом по обычному адресу