### PR TITLE
5096 не берем в чек позиции с нулевой суммой

### DIFF
--- a/Source/Libraries/Core/Business/VodovozBusiness/Domain/Orders/OrderItem.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Domain/Orders/OrderItem.cs
@@ -477,6 +477,8 @@ namespace Vodovoz.Domain.Orders
 
 			return CounterpartyMovementOperation;
 		}
+		
+		public virtual bool HasZeroCountOrSum() => Count <= 0 || Sum == default;
 
 		#endregion
 

--- a/Source/Libraries/Core/Business/VodovozBusiness/Models/CashReceipts/FiscalDocumentPreparer.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Models/CashReceipts/FiscalDocumentPreparer.cs
@@ -47,10 +47,12 @@ namespace Vodovoz.Models.CashReceipts
 				fiscalDocument.ClientINN = order.Client.INN;
 			}
 
-			var countMarkedNomenclatures =
-				cashReceipt.Order.OrderItems.Where(x => x.Nomenclature.IsAccountableInTrueMark).Sum(x => x.Count);
+			var countMarkedNomenclaturesWithPositiveSum =
+				cashReceipt.Order.OrderItems
+					.Where(x => x.Nomenclature.IsAccountableInTrueMark && x.Sum > 0)
+					.Sum(x => x.Count);
 
-			if(countMarkedNomenclatures > CashReceipt.MaxMarkCodesInReceipt)
+			if(countMarkedNomenclaturesWithPositiveSum > CashReceipt.MaxMarkCodesInReceipt)
 			{
 				FillInventPositions(fiscalDocument, cashReceipt, out var cashReceiptSum);
 				FillMoneyPositions(fiscalDocument, cashReceipt.Order.PaymentType, cashReceiptSum);
@@ -70,7 +72,7 @@ namespace Vodovoz.Models.CashReceipts
 		{
 			foreach(var orderItem in cashReceipt.Order.OrderItems)
 			{
-				if(orderItem.Count <= 0)
+				if(orderItem.HasZeroCountOrSum())
 				{
 					continue;
 				}
@@ -163,7 +165,7 @@ namespace Vodovoz.Models.CashReceipts
 			
 			foreach(var orderItem in cashReceipt.Order.OrderItems)
 			{
-				if(orderItem.Count <= 0)
+				if(orderItem.HasZeroCountOrSum())
 				{
 					continue;
 				}
@@ -271,7 +273,7 @@ namespace Vodovoz.Models.CashReceipts
 		private void FillMoneyPositions(FiscalDocument fiscalDocument, CashReceipt cashReceipt)
 		{
 			var order = cashReceipt.Order;
-			var soldItems = order.OrderItems.Where(x => x.Count > 0);
+			var soldItems = order.OrderItems.Where(x => x.Count > 0 && x.Sum > 0);
 			var sum = soldItems.Sum(x => x.Sum);
 
 			AddMoneyPosition(fiscalDocument, order.PaymentType, sum);

--- a/Source/Libraries/Core/Business/VodovozBusiness/Models/TrueMark/OrderReceiptCreator.cs
+++ b/Source/Libraries/Core/Business/VodovozBusiness/Models/TrueMark/OrderReceiptCreator.cs
@@ -64,11 +64,14 @@ namespace Vodovoz.Models.TrueMark
 			try
 			{
 				order = GetOrder();
-				var countMarkedNomenclatures = (int)order.OrderItems.Where(x => x.Nomenclature.IsAccountableInTrueMark).Sum(x => x.Count);
+				var countMarkedNomenclaturesWithPositiveSum = 
+					(int)order.OrderItems
+						.Where(x => x.Nomenclature.IsAccountableInTrueMark && x.Sum > 0)
+						.Sum(x => x.Count);
 
-				if(countMarkedNomenclatures > CashReceipt.MaxMarkCodesInReceipt)
+				if(countMarkedNomenclaturesWithPositiveSum > CashReceipt.MaxMarkCodesInReceipt)
 				{
-					CreateCashReceipts(order, countMarkedNomenclatures);
+					CreateCashReceipts(order, countMarkedNomenclaturesWithPositiveSum);
 				}
 				else
 				{
@@ -105,8 +108,9 @@ namespace Vodovoz.Models.TrueMark
 			var codesInReceipt = default(int);
 			CashReceiptsToSave = new List<CashReceipt>();
 			var receipt = CreateCashReceiptForBigOrder(order, receiptNumber);
+			var positiveSumItems = order.OrderItems.Where(x => x.Sum > 0);
 
-			foreach(var orderItem in order.OrderItems)
+			foreach(var orderItem in positiveSumItems)
 			{
 				if(!orderItem.Nomenclature.IsAccountableInTrueMark)
 				{
@@ -139,8 +143,9 @@ namespace Vodovoz.Models.TrueMark
 		protected virtual void CreateCashReceipt(Order order)
 		{
 			var receipt = CashReceiptFactory.CreateNewCashReceipt(order);
+			var positiveSumItems = order.OrderItems.Where(x => x.Sum > 0);
 			
-			foreach(var orderItem in order.OrderItems)
+			foreach(var orderItem in positiveSumItems)
 			{
 				if(!orderItem.Nomenclature.IsAccountableInTrueMark)
 				{


### PR DESCRIPTION
- при формировании чека не обрабатываем позиции с нулевой суммой, исключая тем самым работу с кодами, если это маркированный товар;
- при формировании фискального документа также пропускаем товары нулевые по сумме;