### PR TITLE
5434 Доработка отчета "Аналитика эксплуатации ТС"

### DIFF
--- a/Source/Applications/Desktop/VodovozViewModels/ViewModels/Reports/Cars/ExploitationReport/CarsExploitationReport.cs
+++ b/Source/Applications/Desktop/VodovozViewModels/ViewModels/Reports/Cars/ExploitationReport/CarsExploitationReport.cs
@@ -31,6 +31,7 @@ namespace Vodovoz.ViewModels.ViewModels.Reports.Cars.ExploitationReport
 		private int _suburbWageDistrictId;
 		private IList<RouteList> _routesListsForPeriod = new List<RouteList>();
 		private IList<Car> _cars = new List<Car>();
+		private IList<int> _excludedCarIds = new List<int>();
 		private IList<int> _ordersIds = new List<int>();
 		private IList<ExploitationReportRouteListDataNode> _routeListsData = new List<ExploitationReportRouteListDataNode>();
 		IDictionary<(int CarId, DateTime RouteListDate), List<ExploitationReportRouteListDataNode>> _groupedRouteListsData =
@@ -136,7 +137,7 @@ namespace Vodovoz.ViewModels.ViewModels.Reports.Cars.ExploitationReport
 					cancellationToken);
 			}
 
-			_cars = _cars.OrderBy(c => c.CarModel.CarTypeOfUse).ThenBy(c => c.Id).ToList();
+			_cars = _cars.Where(x => !_excludedCarIds.Contains(x.Id)).OrderBy(c => c.CarModel.CarTypeOfUse).ThenBy(c => c.Id).ToList();
 			_carsGeoGroups = _carRepository.GetCarsGeoGroups(_uow, _carsIds);
 			_driversNames = await _carRepository.GetDriversNamesByCars(_uow, _carsIds, cancellationToken);
 			_carsNotPriorityDistrictsAddressesCountByDays = await GetNotPriorityDistrictsAddressesCount(cancellationToken);
@@ -1267,6 +1268,7 @@ namespace Vodovoz.ViewModels.ViewModels.Reports.Cars.ExploitationReport
 			IndicatorsType indicatorsType,
 			DeliveryType? deliveryType,
 			CarOwnType carOwnType,
+			int[] excludedCarIds,
 			int[] includedCarModelIds,
 			int[] excludedCarModelIds,
 			CarTypeOfUse? carTypeOfUse,
@@ -1287,6 +1289,7 @@ namespace Vodovoz.ViewModels.ViewModels.Reports.Cars.ExploitationReport
 				_carRepository = carRepository,
 				_undeliveredOrdersRepository = undeliveredOrdersRepository,
 				_deliveryType = deliveryType,
+				_excludedCarIds = excludedCarIds,
 				_includedCarModelIds = includedCarModelIds,
 				_excludedCarModelIds = excludedCarModelIds,
 				_showCarsWithoutData = showCarsWithoutData,

--- a/Source/Applications/Desktop/VodovozViewModels/ViewModels/Reports/Cars/ExploitationReport/CarsExploitationReportViewModel.cs
+++ b/Source/Applications/Desktop/VodovozViewModels/ViewModels/Reports/Cars/ExploitationReport/CarsExploitationReportViewModel.cs
@@ -17,6 +17,7 @@ using Vodovoz.EntityRepositories.Logistic;
 using Vodovoz.EntityRepositories.Undeliveries;
 using Vodovoz.Services;
 using Vodovoz.Settings.Car;
+using Vodovoz.Settings.Logistics;
 using Vodovoz.ViewModels.Dialogs.Logistic;
 using Vodovoz.ViewModels.Journals.FilterViewModels.Logistic;
 using Vodovoz.ViewModels.Journals.JournalViewModels.Logistic;
@@ -31,6 +32,7 @@ namespace Vodovoz.ViewModels.ViewModels.Reports.Cars.ExploitationReport
 		private readonly IRouteListRepository _routeListRepository;
 		private readonly ICarRepository _carRepository;
 		private readonly IUndeliveredOrdersRepository _undeliveredOrdersRepository;
+		private readonly ICarEventSettings _carEventSettings;
 		private readonly ICommonServices _commonServices;
 		private readonly ILifetimeScope _scope;
 		private readonly ICarSettings _carSettings;
@@ -60,6 +62,7 @@ namespace Vodovoz.ViewModels.ViewModels.Reports.Cars.ExploitationReport
 			IUndeliveredOrdersRepository undeliveredOrdersRepository,
 			INavigationManager navigation,
 			IWageSettings wageSettings,
+			ICarEventSettings carEventSettings,
 			ICommonServices commonServices,
 			ILifetimeScope scope,
 			ICarSettings carSettings)
@@ -70,6 +73,7 @@ namespace Vodovoz.ViewModels.ViewModels.Reports.Cars.ExploitationReport
 			_routeListRepository = routeListRepository ?? throw new ArgumentNullException(nameof(routeListRepository));
 			_carRepository = carRepository ?? throw new ArgumentNullException(nameof(carRepository));
 			_undeliveredOrdersRepository = undeliveredOrdersRepository ?? throw new ArgumentNullException(nameof(undeliveredOrdersRepository));
+			_carEventSettings = carEventSettings ?? throw new ArgumentNullException(nameof(carEventSettings));
 			_commonServices = commonServices ?? throw new ArgumentNullException(nameof(commonServices));
 			_scope = scope ?? throw new ArgumentNullException(nameof(scope));
 			_carSettings = carSettings ?? throw new ArgumentNullException(nameof(carSettings));
@@ -245,6 +249,7 @@ namespace Vodovoz.ViewModels.ViewModels.Reports.Cars.ExploitationReport
 					IndicatorsType,
 					DeliveryType,
 					CarOwnType,
+					_carEventSettings.CarsExcludedFromReportsIds,
 					CarModelSelectionFilterViewModel.IncludedCarModelIds,
 					CarModelSelectionFilterViewModel.ExcludedCarModelIds,
 					TypeOfUse,

--- a/Source/Libraries/Infrastructure/Vodovoz.Infrastructure.Persistance/Logistic/CarRepository.cs
+++ b/Source/Libraries/Infrastructure/Vodovoz.Infrastructure.Persistance/Logistic/CarRepository.cs
@@ -309,8 +309,6 @@ namespace Vodovoz.Infrastructure.Persistance.Logistic
 					carsQuery.Where(Restrictions.Not(Restrictions.In(Projections.Property(() => carModelAlias.Id), excludedCarModelIds)));
 				}
 
-				carsQuery.Fetch(SelectMode.Fetch, x => x.GeographicGroups);
-
 				return carsQuery.List<Car>();
 			},
 			cancellationToken);


### PR DESCRIPTION
1. Устранено дублирование строк при установленных нескольких частей города в карточке авто
2. Исключены авто, указанные в настройке БД как исключенные из отчетов